### PR TITLE
chore(flake/nixpkgs): `a6531044` -> `3e2499d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -171,11 +171,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1766309749,
-        "narHash": "sha256-3xY8CZ4rSnQ0NqGhMKAy5vgC+2IVK0NoVEzDoOh4DA4=",
+        "lastModified": 1766651565,
+        "narHash": "sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a6531044f6d0bef691ea18d4d4ce44d0daa6e816",
+        "rev": "3e2499d5539c16d0d173ba53552a4ff8547f4539",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`9f537735`](https://github.com/NixOS/nixpkgs/commit/9f537735e7caecbc559fcf4d4d0e6b7ab100e53f) | `` nixosTests.gitlab.runner: block unstable only on x86_64-linux ``                     |
| [`2bed4702`](https://github.com/NixOS/nixpkgs/commit/2bed4702a5ab31f6ecd5b375367c1a90a5a52f44) | `` jpm: fix incorrect config paths by referencing janet store path ``                   |
| [`1817cd5d`](https://github.com/NixOS/nixpkgs/commit/1817cd5d1b1bf3d201577dae4174669e1358558f) | `` pkl: add shell completion ``                                                         |
| [`0f0a9432`](https://github.com/NixOS/nixpkgs/commit/0f0a9432ce685e5b58aa77250c0ec63d762ce03c) | `` systemd: update homepage ``                                                          |
| [`42a70e3e`](https://github.com/NixOS/nixpkgs/commit/42a70e3ee48ed8710fb3d18c89ef9c9bbade885b) | `` go-judge: 1.10.0 -> 1.11.1 ``                                                        |
| [`d6d60e38`](https://github.com/NixOS/nixpkgs/commit/d6d60e38e48691d689bb0e4089b0133370538905) | `` nixos/matrix-continuwuity: set TimeoutStartSec to account for database migrations `` |
| [`d6e0cc6e`](https://github.com/NixOS/nixpkgs/commit/d6e0cc6e0ca504b5918f5abc4d2551d548a995b9) | `` terraform-providers.auth0_auth0: 1.36.0 -> 1.37.0 ``                                 |
| [`d7308689`](https://github.com/NixOS/nixpkgs/commit/d7308689ff7ac08b0af39b1da48982e1b59e652f) | `` lomiri.lomiri-ui-toolkit: 1.3.5901 -> 1.3.5902 ``                                    |
| [`45a9aec0`](https://github.com/NixOS/nixpkgs/commit/45a9aec01614303eb3bb183a10cf101fe0708eef) | `` rime-wanxiang: 13.8.5 -> 13.9.3 ``                                                   |
| [`ed14a80b`](https://github.com/NixOS/nixpkgs/commit/ed14a80b789cfe64e33d797c8ef48add5c55bd6d) | `` firebase-tools: 15.0.0 -> 15.1.0 ``                                                  |
| [`19a6fa6e`](https://github.com/NixOS/nixpkgs/commit/19a6fa6ecd9eda2ed2749ed9529a5e45eff6c9a2) | `` clickhouse-backup: fix build ``                                                      |
| [`5e51781c`](https://github.com/NixOS/nixpkgs/commit/5e51781c0caf687291ea6ea3c2ce780a872f7dc6) | `` acli: 1.3.8-stable -> 1.3.9-stable ``                                                |
| [`c9ca8d80`](https://github.com/NixOS/nixpkgs/commit/c9ca8d803d3a7f5e1dd28597f40f2eb2003c10bf) | `` libretro.mame2003-plus: 0-unstable-2025-12-13 -> 0-unstable-2025-12-18 ``            |
| [`9f2f1fe2`](https://github.com/NixOS/nixpkgs/commit/9f2f1fe2b0377d977c99c2a4844b4b85dbb94f31) | `` openshift: cleanup ``                                                                |
| [`91bd434f`](https://github.com/NixOS/nixpkgs/commit/91bd434fbbf4e6d9cec252d6303c39ee588f01bc) | `` openshift: 4.16.0 -> 4.19.0-202505210330 ``                                          |
| [`8a0e1f13`](https://github.com/NixOS/nixpkgs/commit/8a0e1f13cecd19e76e08704fecfba8fac8b5286f) | `` terraform-providers.hashicorp_awscc: 1.66.0 -> 1.67.0 ``                             |
| [`ba28bf00`](https://github.com/NixOS/nixpkgs/commit/ba28bf00a0328f68af0a7306e0d904846c1bb6e5) | `` terraform-providers.a10networks_thunder: 1.4.2 -> 1.5.0 ``                           |
| [`bf519620`](https://github.com/NixOS/nixpkgs/commit/bf51962089f10fa483e368d3c52624948ccff254) | `` androidStudioPackages.beta: 2025.2.2.6 -> 2025.2.3.6 ``                              |
| [`9852d866`](https://github.com/NixOS/nixpkgs/commit/9852d86643652c06a08cdf5c293d883a3f8cfc94) | `` rasm: 3.0.1 -> 3.0.3 ``                                                              |
| [`71d5640b`](https://github.com/NixOS/nixpkgs/commit/71d5640bfff9b1417d94ea6cb6ef5f86d79318b7) | `` python3Packages.libipld: fix meta.changelog ``                                       |
| [`2a7573f9`](https://github.com/NixOS/nixpkgs/commit/2a7573f961f5127d7cbeeca370db9bea1b375872) | `` pixi: 0.62.0 -> 0.62.2 ``                                                            |
| [`24d11f6f`](https://github.com/NixOS/nixpkgs/commit/24d11f6feae797945c998bfeea50b2c01d738293) | `` terraform-providers.digitalocean_digitalocean: 2.71.0 -> 2.72.0 ``                   |
| [`b859b033`](https://github.com/NixOS/nixpkgs/commit/b859b0338a3a91e5e79a8ccff61876a0f36c3345) | `` umap: 3.4.2 -> 3.5.0 ``                                                              |
| [`058cb05c`](https://github.com/NixOS/nixpkgs/commit/058cb05c15614b2213cc59ea7891459fdbe09bf8) | `` atlas: 0.38.0 -> 1.0.0 ``                                                            |
| [`bf0527bf`](https://github.com/NixOS/nixpkgs/commit/bf0527bff3b9b581c266080d57a43d87a97e42a4) | `` vigra: 1.12.2 -> 1.12.3 ``                                                           |
| [`0ffe605e`](https://github.com/NixOS/nixpkgs/commit/0ffe605ebe646845218b10a2f76fd43eb8a7c1a9) | `` freshrss: 1.27.1 -> 1.28.0 ``                                                        |
| [`7718d71f`](https://github.com/NixOS/nixpkgs/commit/7718d71fa92813d0c538817f149ba0e0e6ef1933) | `` lux-cli: 0.22.2 -> 0.22.3 ``                                                         |
| [`975cf8e8`](https://github.com/NixOS/nixpkgs/commit/975cf8e8e92b7f73f19b2bbde34aa2668cc1fa5a) | `` bootdev-cli: 1.21.1 -> 1.22.0 ``                                                     |
| [`c09c3e52`](https://github.com/NixOS/nixpkgs/commit/c09c3e522aaf2a06285a5191da81b9b664c23f7d) | `` misconfig-mapper: update changelog entry ``                                          |
| [`211660be`](https://github.com/NixOS/nixpkgs/commit/211660be0a8b16318ee46c72ef2fdb86bf8de30f) | `` python313Packages.aioqsw: modernize ``                                               |
| [`656408ff`](https://github.com/NixOS/nixpkgs/commit/656408fff31a91416f2f695683a93129aaf4f3e0) | `` python313Packages.nibe: modernize ``                                                 |
| [`eecae9bb`](https://github.com/NixOS/nixpkgs/commit/eecae9bb58d0eed7dc36f3761960a80dc21c3c14) | `` python313Packages.iamdata: 0.1.202512231 -> 0.1.202512241 ``                         |
| [`26aca99a`](https://github.com/NixOS/nixpkgs/commit/26aca99af7fe3eead44d11c8b6812f5e09047925) | `` python313Packages.iamdata: 0.1.202512221 -> 0.1.202512231 ``                         |
| [`2b42ee21`](https://github.com/NixOS/nixpkgs/commit/2b42ee21f0eff3e0b24e59bba686379c6080ed52) | `` widelands: 1.2.1 -> 1.3 ``                                                           |
| [`084b2248`](https://github.com/NixOS/nixpkgs/commit/084b2248cacf97fb82da36810f33bd578ce6ee12) | `` mpvScripts.sponsorblock-minimal: 0-unstable-2025-09-09 -> 0-unstable-2025-12-21 ``   |
| [`fdd4a223`](https://github.com/NixOS/nixpkgs/commit/fdd4a223604969743c427e995be5d650722e5c04) | `` hmcl: 3.8.1 -> 3.8.2 ``                                                              |
| [`8e64c7c1`](https://github.com/NixOS/nixpkgs/commit/8e64c7c13aa0acb3b17dae700e0015746463bb5f) | `` libretro.ppsspp: 0-unstable-2025-12-16 -> 0-unstable-2025-12-22 ``                   |
| [`02dec817`](https://github.com/NixOS/nixpkgs/commit/02dec8179d50425b543181330bbc67c896215ced) | `` easyeffects: 8.0.8 -> 8.0.9 ``                                                       |
| [`397a4a0c`](https://github.com/NixOS/nixpkgs/commit/397a4a0c3fdeb63c3c641eb5af9bc388f693b75b) | `` postcss: migrate from nodePackages ``                                                |
| [`9ad1603e`](https://github.com/NixOS/nixpkgs/commit/9ad1603ead58a066654607dfaeb16e99ffc97f2c) | `` tbls: 1.92.1 -> 1.92.2 ``                                                            |
| [`8f88d575`](https://github.com/NixOS/nixpkgs/commit/8f88d575251d6595901b0cb57686adb24c8dfd8c) | `` idris2Packages.pack: add make runtime dependency ``                                  |
| [`5537ea26`](https://github.com/NixOS/nixpkgs/commit/5537ea26424f8c2ee960318cedd92e476c93e206) | `` nixos/n8n: fix malformed env vars ``                                                 |
| [`1d1e9039`](https://github.com/NixOS/nixpkgs/commit/1d1e90397e95e87f6ce93facefc910b880be8172) | `` terraform-providers.linode_linode: 3.6.0 -> 3.7.0 ``                                 |
| [`c6ac8c60`](https://github.com/NixOS/nixpkgs/commit/c6ac8c607c0982589c4d2c1beacbc53d08eaf71f) | `` python3Packages.hcloud: 2.12.0 -> 2.13.0 ``                                          |
| [`c3de9fd9`](https://github.com/NixOS/nixpkgs/commit/c3de9fd9293df90a2dbe06440057a89e8586893d) | `` snitch: 0.1.9 -> 0.2.0 ``                                                            |
| [`784ee28c`](https://github.com/NixOS/nixpkgs/commit/784ee28c6349097f49ebf3e973913e798ebde284) | `` dolibarr: 22.0.3 -> 22.0.4 ``                                                        |
| [`e7244c71`](https://github.com/NixOS/nixpkgs/commit/e7244c71e4bf29b31185b6d63dc1f86a0ef7f865) | `` misconfig-mapper: 1.14.14 -> 1.14.16 ``                                              |
| [`4dfff61d`](https://github.com/NixOS/nixpkgs/commit/4dfff61dbfceb954cab5cfe66d873854e2ee59f1) | `` mktxp: 1.2.14 -> 1.2.16 ``                                                           |
| [`8f114b64`](https://github.com/NixOS/nixpkgs/commit/8f114b64c96041ffdfcce5aa8b9116c65c8c46dc) | `` kickstart: 0.5.0 -> 0.6.0 ``                                                         |
| [`addb357b`](https://github.com/NixOS/nixpkgs/commit/addb357b28f800dec3998a9215887cd5e7a7fc93) | `` koboldcpp: 1.103 -> 1.104 ``                                                         |
| [`ab6928d3`](https://github.com/NixOS/nixpkgs/commit/ab6928d3e273043e9f1715d40cae6f64dd01a58c) | `` zwave-js-ui: 11.9.0 -> 11.9.1 ``                                                     |
| [`92580347`](https://github.com/NixOS/nixpkgs/commit/92580347c8fd38622c65efd7478a0fb693a4e306) | `` nixd: 2.7.0 -> 2.8.0 ``                                                              |
| [`b2a484a3`](https://github.com/NixOS/nixpkgs/commit/b2a484a33c45416309ffda6142cf86400c023041) | `` parallel: 20251122 -> 20251222 ``                                                    |
| [`644624c2`](https://github.com/NixOS/nixpkgs/commit/644624c2465a957ad302353d8b4f5dbb08435704) | `` gnome-pomodoro: 0.28.0 -> 0.28.1 ``                                                  |
| [`35d011d4`](https://github.com/NixOS/nixpkgs/commit/35d011d4b2e94a552f92ecf9fd32d1eba2f4a1e9) | `` go-passbolt-cli: 0.3.2 -> 0.4.0 ``                                                   |
| [`2b7aee7b`](https://github.com/NixOS/nixpkgs/commit/2b7aee7b8a6a56d289e4b16d6d3a6c3bf48119e8) | `` basex: 12.0 -> 12.1 ``                                                               |
| [`0c657710`](https://github.com/NixOS/nixpkgs/commit/0c657710328b44e4bd4554906247ec3b9c6198e0) | `` winbox4: 4.0beta42 -> 4.0beta44 ``                                                   |
| [`6b906cc0`](https://github.com/NixOS/nixpkgs/commit/6b906cc026c0be8ddadd3d1017781ac087fcbc41) | `` nix-sweep: init at 0.8.0 ``                                                          |
| [`eda3355f`](https://github.com/NixOS/nixpkgs/commit/eda3355fc3f99ac803d6d17ad72c0a1c7f12c55a) | `` python3Packages.django-rq: 3.2.1 -> 3.2.2 ``                                         |
| [`14c11c8c`](https://github.com/NixOS/nixpkgs/commit/14c11c8ca591be1c160e274a2707eefe9eeca18d) | `` aws-cdk-cli.tests: fix the eval ``                                                   |
| [`e80537b8`](https://github.com/NixOS/nixpkgs/commit/e80537b82bffbf5acefa92eeb7d367ccf69a5db3) | `` linux/common-config: choose between HIGHMEM4G and HIGHMEM64G ``                      |
| [`06a3aaa5`](https://github.com/NixOS/nixpkgs/commit/06a3aaa51cf280a73ab5dec7d791d2064a770db1) | `` udpspeeder: fix crash ``                                                             |
| [`a772721d`](https://github.com/NixOS/nixpkgs/commit/a772721da00be196b2213a6abcccf6c99db74b39) | `` pangolin-cli: init at 0.2.0 ``                                                       |
| [`395eff3e`](https://github.com/NixOS/nixpkgs/commit/395eff3e311b36fd1bd784d072e0f024deb6b2f7) | `` fluent-bit: 4.2.0 -> 4.2.2 ``                                                        |
| [`627cec58`](https://github.com/NixOS/nixpkgs/commit/627cec58a8ef30738338643ccd8a75507eb3adc7) | `` llama-cpp: 7445 -> 7527 ``                                                           |
| [`763a1c94`](https://github.com/NixOS/nixpkgs/commit/763a1c948ac4f2f79b0858bafefe60127e245523) | `` cherry-studio: 1.7.4 -> 1.7.6 ``                                                     |
| [`1fc29393`](https://github.com/NixOS/nixpkgs/commit/1fc29393b958c7ba4c69b82cc00b1785e97968d1) | `` fclones: cleanup ``                                                                  |
| [`79319994`](https://github.com/NixOS/nixpkgs/commit/79319994853951b7d3f803f93820c49a002f81ce) | `` quark-goldleaf: 1.0.0 -> 1.2.0 ``                                                    |
| [`809d433f`](https://github.com/NixOS/nixpkgs/commit/809d433fcfc168362426098044d0144a3640030d) | `` vimPlugins.lean-nvim: remove nvim-lspconfig from dependencies ``                     |
| [`23b24be9`](https://github.com/NixOS/nixpkgs/commit/23b24be9a4f9c8fb84ed4111337ebf5269c2e9ab) | `` python3.pkgs.beets: use `let in` for version ``                                      |
| [`bef29867`](https://github.com/NixOS/nixpkgs/commit/bef2986729d95d0530c58e8729a675781abf5008) | `` python3.pkgs.beets: allow to override passthru ``                                    |
| [`fa4926a0`](https://github.com/NixOS/nixpkgs/commit/fa4926a0c2a9acc6a7d58bcd2393d2de76ad7d5a) | `` zerofs: 0.22.6 -> 0.22.8 ``                                                          |
| [`fb498a53`](https://github.com/NixOS/nixpkgs/commit/fb498a5341df94596f75ce24743e16474bc8f221) | `` wireplumber: 0.5.12 -> 0.5.13 ``                                                     |
| [`d7030cb5`](https://github.com/NixOS/nixpkgs/commit/d7030cb579163b70a2da200fa37ebf52baa24bde) | `` matrix-continuwuity: 0.5.0-rc.8.1 -> 0.5.0 ``                                        |
| [`c66415a8`](https://github.com/NixOS/nixpkgs/commit/c66415a8944c77edbd797d53fe058138900d5985) | `` python3Packages.dbt-protos: 1.0.412 -> 1.0.413 ``                                    |
| [`188a2a32`](https://github.com/NixOS/nixpkgs/commit/188a2a323dedf73a7d4b5305cee55d18cec84544) | `` htb-toolkit: 0-unstable-2025-08-12 -> 0-unstable-2025-12-19 ``                       |
| [`4db54693`](https://github.com/NixOS/nixpkgs/commit/4db54693b460b2e89f8e2b0ec4d2f44cbd260b8c) | `` bcachefs-tools: 1.33.2 -> 1.33.3 ``                                                  |
| [`f06a701c`](https://github.com/NixOS/nixpkgs/commit/f06a701c80c94768d724d758f2b3f17537f1fa52) | `` python3Packages.garth: 0.5.19 -> 0.5.20 ``                                           |
| [`077cb274`](https://github.com/NixOS/nixpkgs/commit/077cb274dfe6dfea4bcdccb17343194eb04d06e8) | `` gpsd: 3.27 -> 3.27.2 ``                                                              |
| [`2634c36b`](https://github.com/NixOS/nixpkgs/commit/2634c36b6616be240efa9c5f06b6ff1ad3224199) | `` anubis: 1.23.1 -> 1.24.0 ``                                                          |
| [`6d87475b`](https://github.com/NixOS/nixpkgs/commit/6d87475b70fb3c39afe2ddc2d81e42230c9fb3a2) | `` terraform-providers.bpg_proxmox: 0.89.1 -> 0.90.0 ``                                 |
| [`c67620b0`](https://github.com/NixOS/nixpkgs/commit/c67620b0cd73a5120012d858890f8382f18a3fb8) | `` qownnotes: 25.12.6 -> 25.12.7 ``                                                     |
| [`637a71f1`](https://github.com/NixOS/nixpkgs/commit/637a71f143b8793eb8e0f5e0172c7e5d046f414e) | `` terraform-providers.vultr_vultr: 2.27.1 -> 2.28.0 ``                                 |
| [`02f42fd3`](https://github.com/NixOS/nixpkgs/commit/02f42fd3defd8450b8895c921be4ecacb865a6f5) | `` python3Packages.aiodocker: 0.24.0 -> 0.25.0 ``                                       |
| [`e91fa5f8`](https://github.com/NixOS/nixpkgs/commit/e91fa5f815517b075ca4d0fa04504ca7ad415d02) | `` direwolf-unstable: 1.8.1-unstable-2025-11-30 -> 1.8.1-unstable-2025-12-19 ``         |
| [`17d46ab6`](https://github.com/NixOS/nixpkgs/commit/17d46ab6add870604bae5fd9910904cf83fd46ec) | `` androidStudioPackages.canary: 2025.2.3.5 -> 2025.3.1.1 ``                            |
| [`7fba494b`](https://github.com/NixOS/nixpkgs/commit/7fba494b6fddc1226265ac45399736dc595bc8f3) | `` python3Packages.falconpy: 1.5.4 -> 1.5.5 ``                                          |
| [`cd657b20`](https://github.com/NixOS/nixpkgs/commit/cd657b2094ac6d4dd6ded1b15cebf7146106821d) | `` python3Packages.fastcore: 1.9.2 -> 1.9.5 ``                                          |
| [`4b160fdd`](https://github.com/NixOS/nixpkgs/commit/4b160fddf8046b8d8b2f8bba40995e0cbee8b3db) | `` ec2-instance-selector: 3.1.2 -> 3.1.3 ``                                             |
| [`1a34e845`](https://github.com/NixOS/nixpkgs/commit/1a34e84586f01a4a2d0e9e8e79ba142720599fe2) | `` pkgsite: 0-unstable-2025-12-15 -> 0-unstable-2025-12-23 ``                           |