### PR TITLE
chore(flake/nixpkgs): `3e2499d5` -> `c0b0e0fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -171,11 +171,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1766651565,
-        "narHash": "sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU=",
+        "lastModified": 1766902085,
+        "narHash": "sha256-coBu0ONtFzlwwVBzmjacUQwj3G+lybcZ1oeNSQkgC0M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e2499d5539c16d0d173ba53552a4ff8547f4539",
+        "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`78c72ff6`](https://github.com/NixOS/nixpkgs/commit/78c72ff6295eaa21d8ade98d906200d8eba8db68) | `` cryfs: 1.0.2 -> 1.0.3 ``                                                              |
| [`f0324a4f`](https://github.com/NixOS/nixpkgs/commit/f0324a4ff61f567a22581de64c43fb2a32911fa4) | `` idris2Packages.pack: 2025-11-06 -> 2025-12-27 ``                                      |
| [`b6004c36`](https://github.com/NixOS/nixpkgs/commit/b6004c3657d7b514988ad8a64efb66cde2239e07) | `` curl-impersonate-ff: drop ``                                                          |
| [`d43ab313`](https://github.com/NixOS/nixpkgs/commit/d43ab3135e9222e9de98c7b0d4cb89aeefd6b93e) | `` minder: 2.0.2 -> 2.0.3 ``                                                             |
| [`9706187f`](https://github.com/NixOS/nixpkgs/commit/9706187f4ccfdeabbb3d428c5b6bb6945d8c879a) | `` fh: 0.1.26 -> 0.1.27 ``                                                               |
| [`39bb5cb5`](https://github.com/NixOS/nixpkgs/commit/39bb5cb5c89dc4145ecca2c1726ac46051855423) | `` svox: 2018-02-14 -> 2021-05-06 + darwin fix ``                                        |
| [`de8a35f0`](https://github.com/NixOS/nixpkgs/commit/de8a35f04698f186f140a38a73ae8a28240f5e3e) | `` fh: add iamanaws as maintainer ``                                                     |
| [`f5991695`](https://github.com/NixOS/nixpkgs/commit/f5991695bb918d54249dd6790905c4e3c1bfce7e) | `` lucky-commit: add iamanaws as maintainer ``                                           |
| [`2baf62e0`](https://github.com/NixOS/nixpkgs/commit/2baf62e070b8a4bc2853bc0625015bbe91b6212d) | `` nixpkgs-hammering: add iamanaws as maintainer ``                                      |
| [`1a99ca5f`](https://github.com/NixOS/nixpkgs/commit/1a99ca5f243703781452de93e84d8a54457bb74b) | `` oxlint: add iamanaws as maintainer ``                                                 |
| [`09163766`](https://github.com/NixOS/nixpkgs/commit/0916376641a1c86b9c616fbbf581b6b8354c01f6) | `` pods: add iamanaws as maintainer ``                                                   |
| [`f351eecb`](https://github.com/NixOS/nixpkgs/commit/f351eecb610009ebeb8cc60a02adba2cc26fe401) | `` typer: add iamanaws as maintainer ``                                                  |
| [`9c38f63b`](https://github.com/NixOS/nixpkgs/commit/9c38f63b56b7b7fef13fadc353b121c641f6c1dd) | `` repgrep: add iamanaws as maintainer ``                                                |
| [`ed531ed0`](https://github.com/NixOS/nixpkgs/commit/ed531ed04ef57a63a9fd712ed3400cc8919d8b58) | `` linuxKernel.kernels.linux_lqx: 6.17.13 -> 6.18.2 ``                                   |
| [`3f03eed5`](https://github.com/NixOS/nixpkgs/commit/3f03eed529f82f77e9de08d16543af9a834aa8ae) | `` nixf: fix cross compilation ``                                                        |
| [`daa2fd51`](https://github.com/NixOS/nixpkgs/commit/daa2fd5123a98fcf539aa53f6182811f2d475a64) | `` mangojuice: fix hash ``                                                               |
| [`00c3b838`](https://github.com/NixOS/nixpkgs/commit/00c3b838fb3ed4e82ed70c65f5f86459567fabf8) | `` build-support/vm: fix race between qemu & virtiofsd ``                                |
| [`bd4b5d6a`](https://github.com/NixOS/nixpkgs/commit/bd4b5d6a9904f769bc7da97863f0cae4ef6096a1) | `` python3Packages.urllib3-future: 2.15.900 -> 2.15.901 ``                               |
| [`f0d69666`](https://github.com/NixOS/nixpkgs/commit/f0d69666360bf09d77edb7577ea1ed0eb0e6e9ef) | `` cook-cli: 0.19.0 -> 0.19.1 ``                                                         |
| [`98353f01`](https://github.com/NixOS/nixpkgs/commit/98353f01881c67cef17db7f677a8ec3141047fcb) | `` home-assistant-custom-components.powercalc: init at 1.20.0 ``                         |
| [`4ff0a590`](https://github.com/NixOS/nixpkgs/commit/4ff0a590c21ffe1b92ead8afb79475c5733e9982) | `` linuxPackages.ecapture: 1.5.1 -> 1.5.2 ``                                             |
| [`524fb9f8`](https://github.com/NixOS/nixpkgs/commit/524fb9f86d3341082657edace3cb169966449471) | `` vscode-extensions.augment.vscode-augment: 0.654.3 -> 0.696.2 ``                       |
| [`8fe8a27e`](https://github.com/NixOS/nixpkgs/commit/8fe8a27ed57e44a06435eb4ecacc5c9243b58914) | `` home-assistant-custom-components.dreo: 1.5.2 -> 1.5.3 ``                              |
| [`ea054f01`](https://github.com/NixOS/nixpkgs/commit/ea054f015f4ffeaa77ebbc9f3840d4cc51b32827) | `` terraform-providers.tencentcloudstack_tencentcloud: 1.82.47 -> 1.82.49 ``             |
| [`353d2996`](https://github.com/NixOS/nixpkgs/commit/353d299661d3b0b18e391e325fb54c5439099289) | `` terraform-providers.cloudamqp_cloudamqp: 1.40.0 -> 1.41.0 ``                          |
| [`47f579c2`](https://github.com/NixOS/nixpkgs/commit/47f579c20155faa9eb4182f407d3a2b66f43c71d) | `` python3Packages.outlines: fix cuda build by disabling pythonImportsCheck and tests `` |
| [`d40668df`](https://github.com/NixOS/nixpkgs/commit/d40668dfc66766f7de99e24d0f714d86636933d3) | `` gpu-screen-recorder: 5.10.2 -> 5.11.2 ``                                              |
| [`1a748ec9`](https://github.com/NixOS/nixpkgs/commit/1a748ec92a0f39fad3f6be0e842f8bcb48235b34) | `` python3Packages.outlines: 1.2.3 -> 1.2.9 ``                                           |
| [`64b4da6c`](https://github.com/NixOS/nixpkgs/commit/64b4da6cc378adbb5cbb2d16883cc2a4d974c0bd) | `` python3Packages.mistralai: init at 1.10.0 ``                                          |
| [`33ddeff8`](https://github.com/NixOS/nixpkgs/commit/33ddeff83336d4a091ffe5ecf9cf4e4f0f300065) | `` python3Packages.flax: ignore FutureWarning in tests (present since keras 3.13.0) ``   |
| [`486f8947`](https://github.com/NixOS/nixpkgs/commit/486f894778e397ba891a22b3a7325ebdbd0898bb) | `` python3Packages.dm-sonnet: only collect tests under sonnet/ ``                        |
| [`67c4db60`](https://github.com/NixOS/nixpkgs/commit/67c4db6097bafbb0d571c22a7f9570d5517be72c) | `` terraform-providers.e-breuninger_netbox: 5.0.0 -> 5.0.1 ``                            |
| [`f8a99025`](https://github.com/NixOS/nixpkgs/commit/f8a99025845a4b03fd752c269c81b20ce01faf81) | `` python3Packages.mtcnn: skip failing test ``                                           |
| [`d29ce3ea`](https://github.com/NixOS/nixpkgs/commit/d29ce3eaf82ea4840c8ae2ae8f98d6192a8b3ebc) | `` python3Packages.keras: 3.12.0 -> 3.13.0 ``                                            |
| [`b0a2c0c4`](https://github.com/NixOS/nixpkgs/commit/b0a2c0c43175cd41ab956fd15c9c57a93f080c09) | `` unftp: 0.15.1 -> 0.15.2 ``                                                            |
| [`5b01520e`](https://github.com/NixOS/nixpkgs/commit/5b01520e86b2b9bb6ffc4922f017a4315d9bf912) | `` python3Packages.valkey: fix valkey 9.0 compat ``                                      |
| [`6d03fc7c`](https://github.com/NixOS/nixpkgs/commit/6d03fc7c3bbb526ae86d875b7da142c3abe8f257) | `` nixos/doc/rl-2605: add release note for pdns update to v5.0.x series ``               |
| [`776341a9`](https://github.com/NixOS/nixpkgs/commit/776341a9e3afe4e8b538974823a6e0cc26f4e0a0) | `` gemini-cli: 0.22.2 -> 0.22.4 ``                                                       |
| [`c9123aa0`](https://github.com/NixOS/nixpkgs/commit/c9123aa0485784387e53c9e9cec187d6ff50185a) | `` nixosTests.powerdns: pkgs.powerdns -> pkgs.pdns ``                                    |
| [`db9daa27`](https://github.com/NixOS/nixpkgs/commit/db9daa27f4659493976be16ead77802f09619ae6) | `` nixosTests.powerdns: update pdnsutil syntax for pdns 5.0 ``                           |
| [`9ec53f7e`](https://github.com/NixOS/nixpkgs/commit/9ec53f7e3e2d20b26157ad78db1b8b21b8f814c1) | `` pdns: 5.0.0 -> 5.0.2 ``                                                               |
| [`27d0a431`](https://github.com/NixOS/nixpkgs/commit/27d0a431770e699650fd588cb77632ab2a5050a7) | `` pdns: 4.9.8 -> 5.0.0 ``                                                               |
| [`cd55c6a8`](https://github.com/NixOS/nixpkgs/commit/cd55c6a8fcd97902fb1c6e97557672a127a21961) | `` Revert "home-assistant-custom-components.oref_alert: 4.1.1 -> 4.2.1" ``               |
| [`6fd9dded`](https://github.com/NixOS/nixpkgs/commit/6fd9dded2e8e0f729c096428cb298a2cbabe691a) | `` home-assistant-custom-components.moonraker: 1.11.1 -> 1.12.0 ``                       |
| [`10ec0f79`](https://github.com/NixOS/nixpkgs/commit/10ec0f798f5c5168936ee6a1b7d6d80b635d16a9) | `` python313Packages.iamdata: 0.1.202512261 -> 0.1.202512271 ``                          |
| [`79509df7`](https://github.com/NixOS/nixpkgs/commit/79509df70b26d352200b6e891091a58ea2d2decf) | `` maintainers: add brantes ``                                                           |
| [`9636637b`](https://github.com/NixOS/nixpkgs/commit/9636637b160585615e21284f53425b2853695f8a) | `` python313Packages.boto3-stubs: 1.42.16 -> 1.42.17 ``                                  |
| [`24a56c43`](https://github.com/NixOS/nixpkgs/commit/24a56c439ab94305c5b98775148eeec5f6917a09) | `` python313Packages.botocore-stubs: 1.42.16 -> 1.42.17 ``                               |
| [`1402abb1`](https://github.com/NixOS/nixpkgs/commit/1402abb1a6ca751ec3c5d3b374192e59287ce5a0) | `` python312Packages.mypy-boto3-medialive: 1.42.3 -> 1.42.17 ``                          |
| [`f0b6ac46`](https://github.com/NixOS/nixpkgs/commit/f0b6ac46f69f823d4fe9033217e81c1aad8f7d45) | `` home-assistant-custom-components.dwd: 2025.5.0 -> 2025.12.1 ``                        |
| [`9c4df570`](https://github.com/NixOS/nixpkgs/commit/9c4df57016a4fd7f0fc9ff8e3bf3f806b5a78529) | `` performous: Pin to ffmpeg 7 ``                                                        |
| [`f336ef6d`](https://github.com/NixOS/nixpkgs/commit/f336ef6d42fbfb2d5ba08f7be043da728cbe2b08) | `` hyprlauncher: 0.1.3 -> 0.1.4 ``                                                       |
| [`ff079405`](https://github.com/NixOS/nixpkgs/commit/ff0794054456442d1ea03b6b578241da1ba40f7e) | `` ospd-openvas: 22.9.1 -> 22.10.0 ``                                                    |
| [`436548e5`](https://github.com/NixOS/nixpkgs/commit/436548e518150974057af586afb55b7ee16826a6) | `` lib/cli: document toCommandLine ``                                                    |
| [`31e1f1b0`](https://github.com/NixOS/nixpkgs/commit/31e1f1b0f56bca1cc6ca767ba6ef9333179be0a4) | `` emscripten: add updateScript and patch verification ``                                |
| [`e468d095`](https://github.com/NixOS/nixpkgs/commit/e468d095928f1a60ebb2beb793f0bca46e6d2d7b) | `` cdk8s-cli: 2.203.10 -> 2.203.14 ``                                                    |
| [`4253df72`](https://github.com/NixOS/nixpkgs/commit/4253df72399fb96f9ae27602a0e3850017a5e3a0) | `` vimPlugins.kulala-nvim: fix ``                                                        |
| [`acb99429`](https://github.com/NixOS/nixpkgs/commit/acb994295e92a26f7ee5de367a89e0745e55ce42) | `` libphidget22extra: 1.22.20250714 -> 1.23.20250925 ``                                  |
| [`9255e349`](https://github.com/NixOS/nixpkgs/commit/9255e349836c26d26f7d7b2e7afb0b5929374ce7) | `` emscripten: fix patchShebangs and add regression test ``                              |
| [`3e1614f4`](https://github.com/NixOS/nixpkgs/commit/3e1614f4851e5f9117cd232e7c75eda776fabded) | `` emscripten: fix cache ``                                                              |
| [`af15315a`](https://github.com/NixOS/nixpkgs/commit/af15315a0ab6a08b869228cf98ae18c157b545cb) | `` python3Packages.dvc-objects: 5.1.2 -> 5.2.0 ``                                        |
| [`4fb3be54`](https://github.com/NixOS/nixpkgs/commit/4fb3be54b9dc7bc8865ab4e3f4308a9494e94f0c) | `` libsForQt5.fcitx5-qt: 5.1.11 -> 5.1.12 ``                                             |
| [`64ac09cd`](https://github.com/NixOS/nixpkgs/commit/64ac09cdb468b241684edcd0887018e3deedc88c) | `` gemini-cli-bin: 0.22.2 -> 0.22.4 ``                                                   |
| [`cd6872cb`](https://github.com/NixOS/nixpkgs/commit/cd6872cbd64ac32a5ce401c4bfe6599e6ed6155e) | `` kiro: 0.7.21 -> 0.8.0 ``                                                              |
| [`09550217`](https://github.com/NixOS/nixpkgs/commit/09550217a700c60de8e042bcc789dab9ec50928b) | `` home-assistant-custom-components.daikin_onecta: 4.4.3 -> 4.4.4 ``                     |
| [`10d46886`](https://github.com/NixOS/nixpkgs/commit/10d46886cce0d896570fa553d6a4bc91fe317cf3) | `` python3Packages.aiosendspin: 1.1.4 -> 1.1.5 ``                                        |
| [`017a7ddc`](https://github.com/NixOS/nixpkgs/commit/017a7ddcb679e2ae35480410555d1b1870eede3e) | `` mongodb-ce: 8.0.15 -> 8.2.3 ``                                                        |
| [`da5d051c`](https://github.com/NixOS/nixpkgs/commit/da5d051cfe78aacc8d6711a81b55691a0969ff10) | `` python3Packages.sabctools: 9.1.0 -> 9.2.0 ``                                          |
| [`d8cb98b5`](https://github.com/NixOS/nixpkgs/commit/d8cb98b5156011db1ceb4773ed4713c91804d4bc) | `` nixos/knot-resolver: skip config validation when cross-compiling ``                   |
| [`5111a589`](https://github.com/NixOS/nixpkgs/commit/5111a589ea9b26ddba746a8e61c81a37914ba922) | `` goflow2: 2.2.3 -> 2.2.6 ``                                                            |