### PR TITLE
chore(flake/astal): `eb235f88` -> `41b50290`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -75,11 +75,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1769774308,
-        "narHash": "sha256-8Ve6VdUpcYbl8bS5oyDwVnnNobyPxdPmUHGgSDyOazQ=",
+        "lastModified": 1773914523,
+        "narHash": "sha256-GOL+bR30FPImAzy4NNsTMY1gpoINMsLTXR0WJBRSq30=",
         "owner": "Aylur",
         "repo": "astal",
-        "rev": "eb235f8813bdea2a4a38ac228f2efc4e2a8a90af",
+        "rev": "41b50290c6a1cdce7b482897c22fe49286912b9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                       | Message                                                                                    |
| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`41b50290`](https://github.com/Aylur/astal/commit/41b50290c6a1cdce7b482897c22fe49286912b9a) | `` [wireplumber] fix segfault from uninitialized channel_str in volume functions (#440) `` |
| [`d3fa2117`](https://github.com/Aylur/astal/commit/d3fa2117d581b50e63eb3aefbf92d4883fa23f1b) | `` fix(river): update wl-vapi-gen ``                                                       |
| [`433ef2e4`](https://github.com/Aylur/astal/commit/433ef2e46fe0caa2458afdabac96f8ecd7e912cc) | `` rewrite AstalRiver in vala (#422) ``                                                    |
| [`8b39f465`](https://github.com/Aylur/astal/commit/8b39f46535314a2172d65f4426b09c832f3ff759) | `` fix(nix): patch wl-vapi-gen shebang ``                                                  |
| [`42474468`](https://github.com/Aylur/astal/commit/42474468f27ea85f41c013b2d5db1b5e8c9c0a3e) | `` new lib AstalWl: central wayland connection management(#371) ``                         |