### PR TITLE
chore(flake/nixpkgs): `aca4d95f` -> `8110df5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -523,11 +523,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1772773019,
-        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "lastModified": 1774709303,
+        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`921ae4ce`](https://github.com/NixOS/nixpkgs/commit/921ae4ce4c13879e0c725e4c6859eabe5c4b620e) | `` home-assistant-custom-components.tibber_local: fix meta.description `` |
| [`376ba221`](https://github.com/NixOS/nixpkgs/commit/376ba221020775ad694c838b0fbcb68f54bd2659) | `` python3Packages.hatch: skip failing test on darwin ``                  |
| [`98547d62`](https://github.com/NixOS/nixpkgs/commit/98547d62cfcdd4b3150b6ddab2e385d04682b18f) | `` python3Packages.powerfox: 2.1.1 -> 2.1.2 ``                            |
| [`0af61b22`](https://github.com/NixOS/nixpkgs/commit/0af61b22953832e72cdbd4fec4f986a02df947f2) | `` mcporter: init at 0.7.3 ``                                             |
| [`f53a6b2a`](https://github.com/NixOS/nixpkgs/commit/f53a6b2a3775f8829f80bb42ef724818a0613f0c) | `` ecspresso: 2.7.1 -> 2.8.0 ``                                           |
| [`976700a0`](https://github.com/NixOS/nixpkgs/commit/976700a01fe3332ffcb39a01ddbbfae5bb446a1e) | `` python3Packages.python-discovery: 1.2.0 -> 1.2.1 ``                    |
| [`254ce4fd`](https://github.com/NixOS/nixpkgs/commit/254ce4fd60ec79a679e1c7e1fa54ba1b34db1170) | `` hack-font: use installFonts ``                                         |
| [`66cee494`](https://github.com/NixOS/nixpkgs/commit/66cee4940a5ddb46cbec61e81336d3e2e0010c0c) | `` jaq: 2.3.0 -> 3.0.0 ``                                                 |
| [`6d5b9692`](https://github.com/NixOS/nixpkgs/commit/6d5b969281cc0f268e4f9d080a822b6a1f3f91db) | `` magic-vlsi: 8.3.628 -> 8.3.629 ``                                      |
| [`30dfa083`](https://github.com/NixOS/nixpkgs/commit/30dfa083cbc73b67e631becd5b30ac26cf3180b0) | `` canaille: 0.2.2 -> 0.2.3 ``                                            |
| [`8edb13b7`](https://github.com/NixOS/nixpkgs/commit/8edb13b77c9a2bc056d293ca446dbc9b567fffa5) | `` remnote: 1.24.7 -> 1.24.12 ``                                          |
| [`b4113461`](https://github.com/NixOS/nixpkgs/commit/b4113461331edbdef89fc8b591deb354385c0a90) | `` nixos/tests/fish: fix test broken by coreutils 9.10 ``                 |
| [`c5f16752`](https://github.com/NixOS/nixpkgs/commit/c5f167527b44a51c1e8cdd0e519040092ad31b8f) | `` fish: 4.5.0 -> 4.6.0 ``                                                |
| [`2fd8dda0`](https://github.com/NixOS/nixpkgs/commit/2fd8dda08a578e1b2b0cadf8275d8c4ed814693a) | `` roave-backward-compatibility-check: 8.19.0 -> 8.20.0 ``                |
| [`bf558467`](https://github.com/NixOS/nixpkgs/commit/bf5584670856d71f03b4a2e3c29d2194d5280615) | `` fork-cleaner: 2.3.1 -> 2.4.0 ``                                        |
| [`42c93349`](https://github.com/NixOS/nixpkgs/commit/42c93349ea255dbb41d0e471809876952de3fe15) | `` copyparty: 1.20.12 -> 1.20.13 ``                                       |
| [`08ba0ea6`](https://github.com/NixOS/nixpkgs/commit/08ba0ea657da17d85fca81ff796bada4772b862c) | `` codebook: 0.3.34 -> 0.3.36 ``                                          |
| [`2fed2e25`](https://github.com/NixOS/nixpkgs/commit/2fed2e25aaa0f239c11f1358cb07e2e6f1c323d4) | `` firefox-beta-unwrapped: 148.0b15 -> 150.0b2 ``                         |
| [`ce5b88a8`](https://github.com/NixOS/nixpkgs/commit/ce5b88a8827848ee0168f4d2e3e9f77aa8901de6) | `` clorinde: 1.3.1 -> 1.4.0 ``                                            |
| [`e13960df`](https://github.com/NixOS/nixpkgs/commit/e13960df253e3b1ba423056e14477f7763537ccb) | `` terraform-providers.grafana_grafana: 4.28.1 -> 4.28.2 ``               |
| [`8dadac0d`](https://github.com/NixOS/nixpkgs/commit/8dadac0d64de92a6782ea478df7a0e7e9e7ad8e1) | `` incus-lts: 6.0.6 -> 6.0.6-unstable-2026-03-27 ``                       |
| [`08b8a3b8`](https://github.com/NixOS/nixpkgs/commit/08b8a3b85626101241646ca7dcca042b9774e48b) | `` incus: 6.22.0 -> 6.23.0 ``                                             |
| [`441a3303`](https://github.com/NixOS/nixpkgs/commit/441a3303131a2a0b7647fa7349bb79e3ef083184) | `` github-copilot-cli: 1.0.9 -> 1.0.12 ``                                 |
| [`5c91cd7c`](https://github.com/NixOS/nixpkgs/commit/5c91cd7ca056152251e7b6bbc53ae6dcaa597714) | `` dovecot_pigeonhole_2_4: fix build ``                                   |
| [`18fe1d26`](https://github.com/NixOS/nixpkgs/commit/18fe1d263374a21b34e7cd92e9d8096d4afa7665) | `` terraform-providers.hashicorp_awscc: 1.74.0 -> 1.77.0 ``               |
| [`202b690b`](https://github.com/NixOS/nixpkgs/commit/202b690b32fc5cf633c3eb638375e16022cc7336) | `` dovecot: disable lua if !withLua ``                                    |
| [`daa4eb6a`](https://github.com/NixOS/nixpkgs/commit/daa4eb6a93332c667f70ed0a7368b0e46eaf05e3) | `` ares-cli: 3.2.1 -> 3.2.3 ``                                            |
| [`2df2d6fc`](https://github.com/NixOS/nixpkgs/commit/2df2d6fca93b8c6d155ba077915b1018df8d3c8b) | `` terraform-providers.mongodb_mongodbatlas: 2.7.0 -> 2.9.0 ``            |
| [`3821d95d`](https://github.com/NixOS/nixpkgs/commit/3821d95df71b4b273ddda99a69d1639da86f25b6) | `` sampo: fix regex escape in updateScript ``                             |
| [`1b5ea74f`](https://github.com/NixOS/nixpkgs/commit/1b5ea74ff8d334bdb53f7aa723a99d0f0ad1e8d4) | `` step-cli: 0.29.0 -> 0.30.2 ``                                          |
| [`4312e0a2`](https://github.com/NixOS/nixpkgs/commit/4312e0a2d0c1d683dc71b2ffdb9b9f75afb90016) | `` python3Packages.unicode-segmentation-rs: 0.2.1 -> 0.2.3 ``             |
| [`da1a7e5e`](https://github.com/NixOS/nixpkgs/commit/da1a7e5ea65a44a94322de90bfd1f722bcef45ed) | `` hath-rust: 1.14.2 -> 1.15.0 ``                                         |
| [`739403e0`](https://github.com/NixOS/nixpkgs/commit/739403e039ae93d8c575770122aafa84daa2ccae) | `` kubexporter: 0.8.3 -> 0.8.4 ``                                         |
| [`f6c34ae0`](https://github.com/NixOS/nixpkgs/commit/f6c34ae02b687e5f3a06c09dcf27b3fb5580dde5) | `` python3Packages.hatch: 1.16.2 -> 1.16.5 ``                             |
| [`826a7e1a`](https://github.com/NixOS/nixpkgs/commit/826a7e1a56a68662913e3b7e9199fd18177b591f) | `` python3Packages.python-discovery: init at 1.2.0 ``                     |
| [`7025ade3`](https://github.com/NixOS/nixpkgs/commit/7025ade3e9d3ce10aa272df4a977a9135aba238e) | `` python3Packages.ipycanvas: cleanup ``                                  |
| [`75f8c1fc`](https://github.com/NixOS/nixpkgs/commit/75f8c1fc1dd8a8dfcc5dfcff0399772aed3952ed) | `` python3Packages.hatch: init at 1.16.2 ``                               |
| [`9fd41316`](https://github.com/NixOS/nixpkgs/commit/9fd413160b1632e78f43b567ab547c38f7daad11) | `` claude-code: 2.1.84 -> 2.1.86 ``                                       |
| [`c5fc0227`](https://github.com/NixOS/nixpkgs/commit/c5fc0227d330b384f0dbc6e8b8e96052c1c8efa0) | `` terraform-providers.digitalocean_digitalocean: 2.80.0 -> 2.81.0 ``     |
| [`2370a39a`](https://github.com/NixOS/nixpkgs/commit/2370a39a4fccf8f06bd2663b36fbb256eda6cdbd) | `` vte: fix parameterized build without systemd support ``                |
| [`1c51f99c`](https://github.com/NixOS/nixpkgs/commit/1c51f99cb01412ef9028b66b6cea505ad741cfa7) | `` python3Packages.torchaudio: 2.10.0 -> 2.11.0 ``                        |
| [`94198e64`](https://github.com/NixOS/nixpkgs/commit/94198e64e1f230ee12611fd76a20b4bb7aa717ec) | `` python3Packages.torchcodec: 0.10.0 -> 0.11.0 ``                        |
| [`d001cf04`](https://github.com/NixOS/nixpkgs/commit/d001cf04cb32cb4cd3e325368b9c6afa445a97c6) | `` python3Packages.torchvision: 0.25.0 -> 0.26.0 ``                       |
| [`177911f8`](https://github.com/NixOS/nixpkgs/commit/177911f865d89c99d7b37cca41b5c2b7fd3b4bc5) | `` python3Packages.torch: 2.10.0 -> 2.11.0 ``                             |
| [`87027e26`](https://github.com/NixOS/nixpkgs/commit/87027e26fcc51f19a6f241fdf430a240cc22211f) | `` reaper: move to by-name/ ``                                            |
| [`f4c1db4b`](https://github.com/NixOS/nixpkgs/commit/f4c1db4b5039602e9aaa47638c58daa9f742161b) | `` hatch: disable failing tests ``                                        |
| [`5f903a93`](https://github.com/NixOS/nixpkgs/commit/5f903a934d33de12da10f91cff8ba311e12c7336) | `` unofficial-homestuck-collection: 2.7.2 -> 2.8.0 ``                     |
| [`7c18f767`](https://github.com/NixOS/nixpkgs/commit/7c18f767b80d49f5d7bf47253791ff6b39a7a847) | `` terraform-providers.sap_btp: 1.19.0 -> 1.20.1 ``                       |
| [`2929faec`](https://github.com/NixOS/nixpkgs/commit/2929faec90a85a3a0e29c1c34abb5212eb8e73e1) | `` atuin: 18.13.5 -> 18.13.6 ``                                           |
| [`dcbfa10f`](https://github.com/NixOS/nixpkgs/commit/dcbfa10fb8a77425d11a38f76f5b90e781b0ad16) | `` pwru: add miniharinn as a maintainer ``                                |
| [`63807663`](https://github.com/NixOS/nixpkgs/commit/638076636dd823bbede5396d1b6e11517bd420ad) | `` pwru: fix version unknown ``                                           |
| [`dc0dc558`](https://github.com/NixOS/nixpkgs/commit/dc0dc5585c56a52163d9e17766adefd42d266c1e) | `` pwru: 1.0.9 -> 1.0.11 ``                                               |
| [`809cebe8`](https://github.com/NixOS/nixpkgs/commit/809cebe866b5f50a89d4b5859eee3efe1329b774) | `` tailscale: 1.96.3 -> 1.96.4 ``                                         |
| [`1e8fcd7a`](https://github.com/NixOS/nixpkgs/commit/1e8fcd7a8b02a4d69f0fe385e678a18c7a76f27e) | `` nezha-agent: 2.0.1 -> 2.0.2 ``                                         |
| [`6d81c002`](https://github.com/NixOS/nixpkgs/commit/6d81c002f2fee18efbb2cf625b776aaacb7d08f8) | `` python3Packages.langgraph-sdk: 0.3.11 -> 0.3.12 ``                     |
| [`57f10cbc`](https://github.com/NixOS/nixpkgs/commit/57f10cbcfa33a14490cb57347b17dcf233d975b7) | `` python3Packages.langgraph-checkpoint-postgres: 3.0.4 -> 3.0.5 ``       |
| [`56b874c5`](https://github.com/NixOS/nixpkgs/commit/56b874c5197f556b897a9bba9b83f771fd46060b) | `` python3Packages.langchain-openai: 1.1.10 -> 1.1.12 ``                  |
| [`c47cb43a`](https://github.com/NixOS/nixpkgs/commit/c47cb43a724c55e23e30c9fb1ddf654b6f015f34) | `` python3Packages.langchain-aws: 1.4.0 -> 1.4.1 ``                       |
| [`457844d1`](https://github.com/NixOS/nixpkgs/commit/457844d1ffa1f53a353640fb45a164e979f754b4) | `` python3Packages.langchain-core: 1.2.19 -> 1.2.22 ``                    |
| [`7e86343d`](https://github.com/NixOS/nixpkgs/commit/7e86343de445b95814fe56d6f5cd5249ac3c26ca) | `` python3Packages.langchain: 1.2.12 -> 1.2.13 ``                         |
| [`56dc2c50`](https://github.com/NixOS/nixpkgs/commit/56dc2c50d47962bac57dbcc08a41dd1276ea9d10) | `` camilladsp: 3.0.1 -> 4.0.0 ``                                          |
| [`0b112081`](https://github.com/NixOS/nixpkgs/commit/0b112081fa141d3bc5d862222976cea7a446c03f) | `` python3Packages.iamdata: 0.1.202603261 -> 0.1.202603271 ``             |
| [`16052058`](https://github.com/NixOS/nixpkgs/commit/16052058628a94436eb8a32105d4c8d351b46519) | `` python3Packages.google-cloud-storage-control: 1.10.0 -> 1.11.0 ``      |
| [`d3440a28`](https://github.com/NixOS/nixpkgs/commit/d3440a288e3aaa6f70f8efade078aff5718aa6c4) | `` libretro.ppsspp: 0-unstable-2026-03-18 -> 0-unstable-2026-03-27 ``     |
| [`344092c2`](https://github.com/NixOS/nixpkgs/commit/344092c2af3aa2c348de2d4d23d37355202df3bb) | `` python3Packages.langchain-anthropic: 1.3.5 -> 1.4.0 ``                 |
| [`7582f73f`](https://github.com/NixOS/nixpkgs/commit/7582f73f15d6bf82f74d37ccd1651443783c77d4) | `` python3Packages.anthropic: 0.84.0 -> 0.86.0 ``                         |