### PR TITLE
chore(flake/astal): `41b50290` -> `67ddc83e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -75,11 +75,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1773914523,
-        "narHash": "sha256-GOL+bR30FPImAzy4NNsTMY1gpoINMsLTXR0WJBRSq30=",
+        "lastModified": 1777578913,
+        "narHash": "sha256-2Hzr8T4oUtw2q0ZYxrgDB8kvy85QawlhpiQDk4eGOHQ=",
         "owner": "Aylur",
         "repo": "astal",
-        "rev": "41b50290c6a1cdce7b482897c22fe49286912b9a",
+        "rev": "67ddc83e0bdbda6de7f6f15e4fbc5d6b9d2d1b18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                       | Message                                                          |
| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`67ddc83e`](https://github.com/Aylur/astal/commit/67ddc83e0bdbda6de7f6f15e4fbc5d6b9d2d1b18) | `` docs: fix favicon ``                                          |
| [`79ad7388`](https://github.com/Aylur/astal/commit/79ad7388481eb1676ab4642f05fc88601f695b5c) | `` docs: fix base ``                                             |
| [`2d027f0c`](https://github.com/Aylur/astal/commit/2d027f0c8bcafc97116659316c38cc42228e40e5) | `` docs: fix outdir ``                                           |
| [`11acb184`](https://github.com/Aylur/astal/commit/11acb1849c76fe7cfba124e576201359499a4576) | `` docs: move vitepress files into recommended locations ``      |
| [`f744962f`](https://github.com/Aylur/astal/commit/f744962fa465944eab31bbb387105ca37e692df3) | `` docs: fix package lock ``                                     |
| [`6fb7847f`](https://github.com/Aylur/astal/commit/6fb7847f61cb1b7eed6c468f91816aa0e2a7d481) | `` docs: add analytics ``                                        |
| [`594b6182`](https://github.com/Aylur/astal/commit/594b6182c4bc5c37f27fa46f397ea8c794059a1c) | `` docs: move references list to the top ``                      |
| [`80f73639`](https://github.com/Aylur/astal/commit/80f73639d11c8585eada2a983b0e83d36d9aef69) | `` fix: docs ci ``                                               |
| [`de4edd29`](https://github.com/Aylur/astal/commit/de4edd2917d009fe36798825ea0b0d0a04303a08) | `` chore: migrate docs ``                                        |
| [`6e9ed352`](https://github.com/Aylur/astal/commit/6e9ed352252f663b0be9dcbc8c60c4ea4a0dcc47) | `` docs: leave outdir as default ``                              |
| [`b259ee02`](https://github.com/Aylur/astal/commit/b259ee0281656d24a8bcde5ef0319cf3dbdb146b) | `` docs: add vercel ``                                           |
| [`2ca3a6f9`](https://github.com/Aylur/astal/commit/2ca3a6f92e1fdfc0c75db51e698adc0e5af387e0) | `` docs: add vercel ``                                           |
| [`350acc91`](https://github.com/Aylur/astal/commit/350acc910be7c1b80c6a293bd3e02ed65154909a) | `` feat(quarrel): parse signal and special flag ``               |
| [`63de29c4`](https://github.com/Aylur/astal/commit/63de29c4679c21fe2921e29adee9da39dc99d49f) | `` chore: symlink gir.py ``                                      |
| [`d401e669`](https://github.com/Aylur/astal/commit/d401e66969e7625fa19d63a10ab5fdb957e53746) | `` feat: libquarrel ``                                           |
| [`f6f559b8`](https://github.com/Aylur/astal/commit/f6f559b876d36529d5b058e713601a6c07fe7ff4) | `` nix: mkAstalPkg require full gir name instead of suffix ``    |
| [`6e49ec97`](https://github.com/Aylur/astal/commit/6e49ec972f5d85437ce80e8b511d22b35a91b0df) | `` fix(wireplumber): fix node removal ``                         |
| [`0d367aac`](https://github.com/Aylur/astal/commit/0d367aacb1b982ce09a934eb69d7bbf2c9cbe541) | `` fix(wireplumber): add more null checks ``                     |
| [`b6d3a62e`](https://github.com/Aylur/astal/commit/b6d3a62e97a389d81d55c02485c4acffc9a34522) | `` fix(cava): use the proper array length to clear the values `` |