### PR TITLE
Senior audit pass: 33 fixes across correctness, perf, and architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dotfiles/fred/.config/nvim/lazy-lock.json
 *.pre-commit-config.yaml
 .DS_Store
 @girs
+config/**/*.js
+config/node_modules
+config/package-lock.json

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -306,6 +306,120 @@ timer fires, cancel the collapse. Same debounce pattern as C-1.11.
 
 ---
 
+### `[x] C-1.16` Tray PopoverMenu × appmenu-glib-translator UAF crash
+
+**Files:** `config/left/sys-tray/tray-item.tsx`,
+`config/left/sys-tray/menu.tsx` (new),
+`config/left/sys-tray/dbusmenu.tsx` (new),
+`config/styles/components/_tray.scss`
+
+**Symptom:** Intermittent SIGSEGV in `g_variant_type_info_query` /
+`g_variant_type_info_get_type_string`, with a preceding burst of
+`g_atomic_ref_count_dec: assertion 'old_value > 0' failed` criticals,
+seconds-to-minutes after fred-bar starts. gdb showed zero JS frames
+between `g_application_run` and the segfault — the crash was on a
+GLib idle source `get_layout_idle` inside
+`libappmenu-glib-translator.so.0`, scheduled in response to a
+`com.canonical.dbusmenu` `LayoutUpdated` DBus signal from
+NetworkManager (fires on every Wi-Fi scan tick).
+
+**Root cause:** `appmenu-glib-translator` (the library that
+materialises a `GMenuModel` + `GActionGroup` from a remote
+`com.canonical.dbusmenu` object) installs `GVariant` and
+`GVariantTypeInfo` pointers into the model's attribute table _by
+reference_, then frees them when its own `dbus_menu_item_t` state
+machine processes an incoming `LayoutUpdated` signal. Any read from
+the resulting `GMenuModel` after that free dereferences the dangling
+type info. The crash reproduces under:
+
+- `Gtk.PopoverMenu.new_from_model(item.menu_model)` (model walk at
+  construction).
+- Hand-rolled `GMenuModel` walk using the borrowing accessor
+  `iterate_item_attributes` (reads borrowed `GVariantTypeInfo`).
+- Hand-rolled walk using the _copying_ accessor
+  `get_item_attribute_value` (GLib's default implementation,
+  `g_menu_model_real_get_item_attribute_value`, still calls
+  `g_variant_is_of_type` on the borrowed type info before copying —
+  same UAF).
+
+In short: **any read of a translator-owned `GMenuModel` is unsafe**,
+regardless of accessor. Documented upstream as
+[Aylur/astal#398](https://github.com/Aylur/astal/issues/398). Several
+mitigations attempted before settling on the fix below:
+
+1. Cache popover + invalidate on `notify::menu-model` — broke
+   submenu affordances (`PopoverMenu` bakes structure at construct
+   time, so popovers built before NM's async Wi-Fi fill have no
+   submenu arrow).
+2. Rebuild popover on every click via `new_from_model` — still
+   crashed inside `gtk_menu_tracker_item_new` →
+   `g_menu_item_get_attribute`.
+3. Hand-roll `Gtk.Popover` from a `GMenuModel` walk using the
+   "copying" `get_item_attribute_value` accessor — still crashed in
+   `g_menu_model_real_get_item_attribute_value` →
+   `g_variant_is_of_type` → `g_variant_type_info_get_type_string`.
+
+**Fix (applied):** Bypass the translator entirely. Talk to the
+remote `com.canonical.dbusmenu` object ourselves over D-Bus, decode
+the reply into pure JS data, and never touch
+`item.menu_model` / `item.action_group`.
+
+- **`config/left/sys-tray/dbusmenu.tsx`** (new) — minimal direct
+  dbusmenu client:
+  - `aboutToShow(busName, path, parentId)` → DBus `AboutToShow(i)`
+    so lazy menus (NM "Available Networks", Discord per-server)
+    populate before we read.
+  - `fetchMenuSubtree(busName, path, parentId, depth)` → DBus
+    `GetLayout(i i as)`; `recursiveUnpack()` the reply _once_ and
+    return a pure-JS `MenuNode` tree. After this returns we never
+    touch the source `GVariant` again, so subsequent translator or
+    app mutations cannot affect our widgets.
+  - `sendClicked(busName, path, id)` → DBus `Event(i s v u)` with
+    `eventId="clicked"`, used for leaf activation and toggle/radio
+    rows alike.
+  - `dbusCall()` helper wraps `Gio.DBusConnection.call` in an
+    explicit Promise via the callback overload — the gir's
+    Promise-form overload errors at runtime with "At least 10
+    arguments required, but only 9 passed".
+  - `getBus()` uses `bus_get_sync` (cached singleton, effectively
+    free) instead of `bus_get`, which had a similar overload
+    ambiguity.
+
+- **`config/left/sys-tray/menu.tsx`** (new) — builds a `Gtk.Popover`
+  tree from a `MenuNode`. Plain `Gtk.Box` of `Gtk.Button` rows,
+  trailing `object-select-symbolic` / `radio-checked-symbolic` /
+  `radio-symbolic` / `go-next-symbolic` glyphs for
+  checkmark/radio/submenu, idle-`unparent` on close. Mnemonic
+  stripping handles `_` markers and `__` literal underscores.
+
+- **`config/left/sys-tray/tray-item.tsx`** — `popupMenu()` is now
+  async: extracts the well-known bus name from `item.item_id`
+  (`service + path` per AstalTray `tray-item.vala:278`),
+  `fetchMenuLayout()`s the root with `depth=1`, hands the
+  `MenuNode` to `buildTrayMenu()`. Reconfirms the single-open
+  invariant after the fetch resolves in case the user clicked
+  elsewhere meanwhile.
+
+**Freshness (sub-fix):** NetworkManager and similar volatile-menu
+apps rebuild submenu subtrees with fresh IDs every Wi-Fi scan
+(seconds). Caching the initial `GetLayout(0, -1)` would leave us
+sending `Event(clicked, id)` for items the server already replaced
+— surfaced as
+`GDBus.Error:…_LIBDBUSMENU_2dGLIB.Code0: The ID supplied N does not
+refer to a menu item we have`. So we fetch lazily:
+
+- Root popover open → `GetLayout(0, depth=1)` (just root +
+  immediate children, with `hasSubmenu` flags).
+- Submenu row clicked → `AboutToShow(node.id)` +
+  `GetLayout(node.id, depth=-1)`, build & pop a fresh child
+  popover; idle-unparent on close. No caching across opens.
+
+**Residual risk:** A sub-millisecond race between a submenu's
+`GetLayout` reply and a server-side rebuild remains theoretically
+possible; `sendClicked` swallows the resulting error at debug level.
+
+---
+
 ## 2. Memory / performance
 
 ### `[x] C-2.1` `systemState` 250 ms churn

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -210,7 +210,7 @@ needed, make it async.
 
 ---
 
-### `[ ] C-1.10` Tray-item: action group registered under 4 prefixes
+### `[x] C-1.10` Tray-item: action group registered under 4 prefixes
 
 **File:** `config/left/sys-tray/tray-item.tsx:42-48`
 
@@ -223,7 +223,7 @@ spec).
 
 ---
 
-### `[ ] C-1.11` Workspaces popover: closes on hover from button to popover
+### `[x] C-1.11` Workspaces popover: closes on hover from button to popover
 
 **File:** `config/center/workspaces.tsx:222-231`
 
@@ -235,7 +235,7 @@ cancel pending close, on `leave` re-arm.
 
 ---
 
-### `[ ] C-1.12` Backdrop double-add to App
+### `[x] C-1.12` Backdrop double-add to App
 
 **File:** `config/helpers/backdrop.tsx:53-58`
 
@@ -247,23 +247,21 @@ other.
 
 ---
 
-### `[~] C-1.13` Mixed timer APIs (`setInterval` / `setTimeout` vs `GLib.timeout_add`)
+### `[x] C-1.13` Mixed timer APIs (`setInterval` / `setTimeout` vs `GLib.timeout_add`)
 
-**Files:**
+**Files (all migrated):**
 
-- `config/center/workspaces.tsx:214` (`setTimeout`) — handled by C-1.11
-- `config/compositors/niri.ts:283` (`setInterval`) — done (C-2.5 replaced
-  the entire poll with an event-stream subscription)
+- `config/center/workspaces.tsx` — open/close hover delays now use
+  `GLib.timeout_add` (resolved alongside C-1.11)
+- `config/compositors/niri.ts:283` (`setInterval`) — replaced by event
+  stream (C-2.5)
 - `config/right/network/network.tsx:205` (`setInterval`) — done
 - `config/right/battery/battery.tsx:147` (`setInterval`) — done
 
-`setInterval`/`setTimeout` are AGS shims. They lack priority control and
-don't survive widget cleanup robustly. The rest of the codebase uses
-`GLib.timeout_add` with self-rescheduling for sleep-cascade safety.
-
-**Fix:** standardize on `GLib.timeout_add` + `SOURCE_REMOVE` self-reschedule
-(pattern already used in `time-pill.tsx`, `media-player.tsx`,
-`tooltip.tsx`).
+`setInterval`/`setTimeout` are AGS shims with no priority control and
+fragile cleanup semantics. Standardised on `GLib.timeout_add` + explicit
+`GLib.source_remove` for cancellation, matching the pattern already used
+in `time-pill.tsx`, `media-player.tsx`, and `tooltip.tsx`.
 
 ---
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -557,7 +557,7 @@ document which property is missed; if no, drop the poll.
 
 ---
 
-### `[ ] C-2.9` Tray-item tooltip captured at construction
+### `[x] C-2.9` Tray-item tooltip captured at construction
 
 **File:** `config/left/sys-tray/tray-item.tsx:129-135`
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -266,6 +266,27 @@ don't survive widget cleanup robustly. The rest of the codebase uses
 
 ---
 
+### `[x] C-1.14` Tray dropdown menu clipped on the left
+
+**File:** `config/left/sys-tray/tray-item.tsx:38`,
+`config/styles/components/_tray.scss:35-36`
+
+`ensurePopover()` called `popover.set_position(Gtk.PositionType.LEFT)`,
+which anchors the popover to the **left side of** the tray button — on
+a top bar with the tray on the left edge of the screen the menu opens
+off-screen and the monitor edge clips it. Layered on top of that, the
+`.tray-menu` SCSS rule applied `margin-left: -32px`, shoving the menu
+another 32 px further left.
+
+**Fix (applied):** anchor `Gtk.PositionType.BOTTOM` so the menu drops
+straight down from the bar (matching every other GTK status tray) and
+remove the `margin-left: -32px` / `margin-top: 32px` workarounds. GTK 4
+auto-flips a BOTTOM popover horizontally when it would overflow the
+monitor's right edge, so this works regardless of where along the bar
+a given tray icon sits.
+
+---
+
 ## 2. Memory / performance
 
 ### `[x] C-2.1` `systemState` 250 ms churn

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -482,7 +482,7 @@ N_monitors × N_popups × 20 wakeups/sec.
 
 ---
 
-### `[ ] C-2.4` Media player: rebuild on active-player swap
+### `[x] C-2.4` Media player: rebuild on active-player swap
 
 **File:** `config/sidebar/media-player.tsx:447-503`
 
@@ -544,7 +544,7 @@ try/catch arms; control flow becomes obvious.
 
 ---
 
-### `[ ] C-2.8` Battery 2 s poll redundant with `notify::*`
+### `[x] C-2.8` Battery 2 s poll redundant with `notify::*`
 
 **File:** `config/right/battery/battery.tsx:147`
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -360,7 +360,7 @@ of `C-1.2`). Use `Gio.Subprocess` + `Gio.DataInputStream.read_line_async`.
 
 ---
 
-### `[ ] C-2.6` `Gio.AppInfo.get_all()` called per icon resolve
+### `[x] C-2.6` `Gio.AppInfo.get_all()` called per icon resolve
 
 **File:** `config/helpers/icon-resolver.tsx:39`
 
@@ -381,7 +381,7 @@ Plus a `Map<string, Gio.Icon | null>` memo keyed by `appClass`.
 
 ---
 
-### `[ ] C-2.7` Dead try/catch arms around `Gio.ThemedIcon.new()`
+### `[x] C-2.7` Dead try/catch arms around `Gio.ThemedIcon.new()`
 
 **File:** `config/helpers/icon-resolver.tsx:31, 69, 78, 87, 94`
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,536 @@
+# fred-bar audit
+
+A senior-engineer pass over `config/`. Findings are grouped and ordered by
+impact. Each item carries a stable ID (e.g. `C-1.1`) so we can reference it
+in commits and PRs as we work through the list.
+
+Status legend: `[ ]` open · `[x]` done · `[~]` in progress · `[-]` deferred
+
+User-facing summary of the two most-felt symptoms today:
+
+- **Notification spam from volume / brightness OSDs** → `C-1.1`.
+- **Window titles go stale** (browser tab change, terminal cwd, etc.)
+  without the bar updating → `C-1.2`. Root cause confirmed below.
+
+---
+
+## 1. Correctness bugs
+
+### `[ ] C-1.1` Notifications: missing freedesktop hint handling
+
+**File:** `config/services/notifications.tsx:36-62`
+
+`handleNewNotification` ignores three hints that determine whether a
+notification should be displayed and/or persisted at all:
+
+- `transient: true` — spec: do **not** add to history. Volume/brightness
+  OSDs, swayosd, and `notify-send -h boolean:transient:true` rely on this.
+  fred-bar shows them as popups _and_ keeps them in the persistent list.
+
+- `x-canonical-private-synchronous: <tag>` — spec extension used by
+  `notify-send -h string:x-canonical-private-synchronous:volume` and by
+  `config/right/speaker-volume/volume.tsx`. Means: replace any pending
+  notification with the same tag, do not persist. Without it, scrolling
+  the volume slider produces N popups + N persisted entries.
+
+- `urgency: 0` (low) typically pairs with transient; system OSD spam is
+  almost always low-urgency.
+
+**Decision (recorded):** strict-spec behavior — transient notifications
+appear in the popup only and never enter the persistent history.
+
+**Fix sketch:**
+
+1. Extend `NotificationData` with `transient: boolean` and
+   `syncTag: string | null`.
+2. Read hints in `handleNewNotification` via the AstalNotifd hint API
+   (`n.get_hint_string("x-canonical-private-synchronous")`,
+   `n.get_hint_boolean("transient")` — verify exact API surface).
+3. If `syncTag` is set: find an existing popup with same tag + `appName`,
+   dismiss/replace it in `PopupNotificationContainer`, do not add to
+   history (mark in `dismissedIds` so `getNotifications()` filters it).
+4. If `transient`: route to popup listeners only; mark dismissed-on-popup
+   so it never enters history.
+5. Mirror filtering in `getNotifications()` so transients can never
+   reappear after a rebuild.
+
+---
+
+### `[ ] C-1.2` Window titles go stale
+
+**Files:** `config/compositors/hyprland.ts:120-124`,
+`config/compositors/niri.ts:283-321`,
+`config/center/window-title.tsx`
+
+Two compounding root causes, one per compositor:
+
+**Hyprland:** `notify::focused-title` is connected on the
+`Hyprland.Hyprland` manager object. Astal's binding emits this signal on
+the focused **client** object, not the manager — so the signal never
+fires for title-only changes (browser tab switch, terminal cwd update).
+Updates only happen via `notify::focused-client`, which fires on focus
+swap but not on in-window title change.
+
+**Niri:** `connect()`'s 200 ms poll tracks `active_window_id` per monitor
+but does **not** track window titles. `getAllWorkspacesJson()` reads only
+the workspaces JSON; titles live in `niri msg --json windows`. Title
+changes within the same focused window leave the cached signature
+unchanged and `onFocusedWindowChanged` never fires.
+
+**Tertiary:** `window-title.tsx` early-returns icon updates if
+`addressChanged` is false (correct), but the whole `update()` call still
+requires the adapter to fire the signal. No fire → no update.
+
+**Fix sketch:**
+
+- Hyprland: track the currently focused client; connect `notify::title`
+  on it; re-bind on `notify::focused-client`. Pseudocode:
+
+  ```ts
+  let lastFocused: Hyprland.Client | null = null;
+  let titleHandler: number | null = null;
+
+  const rewire = () => {
+    if (lastFocused && titleHandler !== null) {
+      lastFocused.disconnect(titleHandler);
+    }
+    lastFocused = this.hypr.focused_client;
+    titleHandler =
+      lastFocused?.connect("notify::title", () =>
+        fire("onFocusedWindowChanged"),
+      ) ?? null;
+    fire("onFocusedWindowChanged");
+  };
+
+  this.hypr.connect("notify::focused-client", rewire);
+  ```
+
+- Niri: best fix is `C-2.5` (event-stream). Until then, include title in
+  the polled signature.
+
+**Cross-link:** `C-2.5` (niri event-stream) supersedes the niri half.
+
+---
+
+### `[ ] C-1.3` Volume widget: duplicate `notify::default-speaker` handler
+
+**File:** `config/right/speaker-volume/volume.tsx:168, :201`
+
+Two separate handlers connected on the same signal. Only the first id is
+captured in `speakerChangedId`; the second leaks for the lifetime of the
+process. Both call `update()` on speaker change, doubling the work.
+
+**Fix:** remove the second `connect`; ensure the single tracked id is
+disconnected in `_cleanup`.
+
+---
+
+### `[ ] C-1.4` Calendar fetch race on rapid day navigation
+
+**File:** `config/right/time-pill/calendar-service.tsx`
+
+Rapid `nextDay()` / `previousDay()` taps can resolve old fetches after
+newer ones, painting stale data.
+
+**Fix:** monotonically increasing `requestId`; capture at call site;
+ignore the response if it doesn't match the latest. Same pattern applies
+to DDC `getvcp` polling in `config/sidebar/sliders.tsx:401-424`.
+
+---
+
+### `[ ] C-1.5` Network pill: `notify` (no detail) is too broad
+
+**File:** `config/right/network/network.tsx:201-202, :205-213`
+
+`network.wifi?.connect("notify", update)` fires for _every_ property
+change — including signal-strength jitter every few seconds. Each tick
+re-shells `nmcli` synchronously on the GTK main thread (line 181 inside
+`update()`, plus the 3 s `setInterval` poll at 205).
+
+**Fixes:**
+
+- Subscribe to specific properties (`notify::strength`, `notify::ssid`,
+  `notify::internet`, `notify::active-access-point`).
+
+- Move VPN detection off the main thread (`Gio.Subprocess` async, or
+  better: see `C-3.1`).
+
+- Best long-term: replace polling with `nmcli monitor` long-running pipe
+  or D-Bus `org.freedesktop.NetworkManager` ActiveConnections
+  PropertyChanged.
+
+---
+
+### `[ ] C-1.6` Connectivity-toggles: same nmcli-on-main issue
+
+**File:** `config/sidebar/connectivity-toggles.tsx:12-35, :308-319`
+
+Same synchronous `nmcli` shelling pattern. Two files
+(`network.tsx` + `connectivity-toggles.tsx`) each spawn `nmcli` every
+3 s independently.
+
+**Fix:** centralize in `config/services/vpn.tsx` (see `C-3.1`).
+
+---
+
+### `[ ] C-1.7` Sliders: `getDDCMonitors()` blocks on first sidebar open
+
+**File:** `config/sidebar/sliders.tsx:51-125, :681-687`
+
+`spawn_command_line_sync("ddcutil detect …")` can take 1-5 s and runs on
+the main loop. The pre-warm at the bottom of the file claims to fix this
+but itself uses `_sync` 100 ms after module load — same bug.
+
+**Fix:** detect monitors via `Gio.Subprocess` async with a stdout reader
+callback; populate `ddcMonitorsCache` from the callback; fire a
+listener-set so widgets refresh.
+
+---
+
+### `[ ] C-1.8` Brightness slider: initial DDC fetch fires twice
+
+**File:** `config/sidebar/sliders.tsx:397-424`
+
+Lines 397-399 do an `_async` call whose output is discarded; lines
+401-424 do a second `_sync` call 500 ms later. Drop the first.
+
+---
+
+### `[ ] C-1.9` System actions: 3× synchronous `pgrep` per construction
+
+**File:** `config/sidebar/system-actions.tsx:19-46`
+
+Every `SystemActions()` call (each sidebar open) spawns up to three
+`pgrep -x` processes synchronously. Compositor doesn't change at
+runtime.
+
+**Fix:** detect once at module load (via `services/compositor-detect.tsx`,
+see `C-3.1`); reuse the cached value; if `pgrep` fallback is genuinely
+needed, make it async.
+
+---
+
+### `[ ] C-1.10` Tray-item: action group registered under 4 prefixes
+
+**File:** `config/left/sys-tray/tray-item.tsx:42-48`
+
+The same `action_group` is inserted under `dbusmenu`, `app`, `unity`,
+`indicator`. Works, but duplicates entries in GTK's action map per item.
+
+**Fix:** parse the menu_model once for action references, register only
+the prefixes actually used. Default to `dbusmenu` (StatusNotifierItem
+spec).
+
+---
+
+### `[ ] C-1.11` Workspaces popover: closes on hover from button to popover
+
+**File:** `config/center/workspaces.tsx:222-231`
+
+Moving from the workspace button into the popover triggers a `leave`
+event on the button, which calls `popover.popdown()`. Popover unusable.
+
+**Fix:** add a `Gtk.EventControllerMotion` to the popover; on `enter`
+cancel pending close, on `leave` re-arm.
+
+---
+
+### `[ ] C-1.12` Backdrop double-add to App
+
+**File:** `config/helpers/backdrop.tsx:53-58`
+
+Calls both `addWindow` and `add_window`. Only one exists in any given
+AGS version.
+
+**Fix:** detect once (typeof check), call the one that exists, drop the
+other.
+
+---
+
+### `[ ] C-1.13` Mixed timer APIs (`setInterval` / `setTimeout` vs `GLib.timeout_add`)
+
+**Files:**
+
+- `config/center/workspaces.tsx:214` (`setTimeout`)
+- `config/sidebar/connectivity-toggles.tsx:205` — actually uses
+  GLib.timeout_add but cross-check
+
+- `config/right/network/network.tsx:205` (`setInterval`)
+- `config/right/battery/battery.tsx:147` (`setInterval`)
+
+`setInterval`/`setTimeout` are AGS shims. They lack priority control and
+don't survive widget cleanup robustly. The rest of the codebase uses
+`GLib.timeout_add` with self-rescheduling for sleep-cascade safety.
+
+**Fix:** standardize on `GLib.timeout_add` + `SOURCE_REMOVE` self-reschedule
+(pattern already used in `time-pill.tsx`, `media-player.tsx`,
+`tooltip.tsx`).
+
+---
+
+## 2. Memory / performance
+
+### `[ ] C-2.1` `systemState` 250 ms churn
+
+**File:** `config/right/system/state/modules/system.tsx:19`,
+consumer `config/right/system/state-pill.tsx`
+
+`createPoll(INITIAL, 250, fn)` returns a fresh object literal every
+tick. Subscribers fire 4 ×/sec; `state-pill.tsx` rebuilds icon widgets
+on every emit. Likely the largest contributor to baseline CPU/mem
+growth.
+
+**Two-part fix (do both):**
+
+1. Memoize at source: in the poll fn, build the state, deep-compare to
+   last (severity + icons array + summary + sources), return last
+   reference if equal.
+2. Diff at consumer: `state-pill.tsx` should mutate child labels
+   (`set_label`, css class toggles) instead of rebuilding.
+
+**Better long-term:** delete the poll entirely. Each underlying module
+(idleInhibit, media, update, network, notification) already has a
+signal/service — wire as event sources and recompute only on change.
+
+---
+
+### `[ ] C-2.2` Tooltip widget churn on mouse-move
+
+**File:** `config/helpers/tooltip.tsx:28-79`
+
+Existing FIXME flags this. Each `query-tooltip` (fires on every move
+inside the anchor) creates a fresh `Gtk.Frame + Gtk.Box + Gtk.Label`.
+
+**Fix:** cache the trio per anchor in closure; on subsequent calls just
+`label.set_label(text)` and toggle css classes. Verify whether
+`tooltip.set_custom(frame)` reparents/destroys; if so, caching needs a
+strategy that survives that (test under `G_DEBUG=gc-friendly`).
+
+---
+
+### `[ ] C-2.3` Multi-monitor popups: per-popup 50 ms timer
+
+**File:** `config/notifications/popup.tsx:144`,
+`config/notifications/popup-window.tsx`
+
+Each `PopupNotificationWindow` spawns its own progress-bar timer at
+50 ms cadence. With multiple monitors and several popups visible:
+N_monitors × N_popups × 20 wakeups/sec.
+
+**Decision (recorded):** popups appear on **focused monitor only**.
+
+**Fix:**
+
+1. Determine focused monitor at the popup container level (Astal
+   provides current focused output via the compositor adapter).
+2. Only that monitor's container subscribes to popup events; switch
+   subscriber on focus change.
+3. Bonus: share a single 100 ms timer across all live popups — one
+   source, all popups read the elapsed time on tick.
+
+---
+
+### `[ ] C-2.4` Media player: rebuild on active-player swap
+
+**File:** `config/sidebar/media-player.tsx:447-503`
+
+The 2 s `playerSwitchPoll` rebuilds the entire `PlayerWidget` whenever
+the "active" player changes (Spotify ↔ Firefox). Artwork, labels,
+controls — all rebuilt. Only signal bindings actually need to swap.
+
+**Fix:** track `currentPlayerId`; if swap is to a different player,
+disconnect old signals, rebind to new player, call `update()`. Skip the
+widget teardown.
+
+---
+
+### `[ ] C-2.5` Niri adapter: drop polling for event-stream
+
+**File:** `config/compositors/niri.ts:283-321`
+
+The 200 ms poll runs 3 sync subprocess calls per tick:
+`getWorkspaces()`, `getFocusedWorkspace()`, `getAllWorkspacesJson()`.
+That's ~15 fork/exec/sec under niri at idle.
+
+**Decision (recorded):** switch to event-stream.
+
+**Fix:** spawn `niri msg --json event-stream` as a long-running process;
+parse stdout line-by-line; emit handler events from incoming
+`WorkspacesChanged`, `WorkspaceActivated`, `WindowFocusChanged`,
+`WindowOpenedOrChanged` (the latter carries title — fixes the niri half
+of `C-1.2`). Use `Gio.Subprocess` + `Gio.DataInputStream.read_line_async`.
+
+---
+
+### `[ ] C-2.6` `Gio.AppInfo.get_all()` called per icon resolve
+
+**File:** `config/helpers/icon-resolver.tsx:39`
+
+Every workspace preview, window-title update, notification re-enumerates
+all installed `.desktop` files.
+
+**Fix:**
+
+```ts
+const monitor = Gio.AppInfoMonitor.get();
+let appsCache = Gio.AppInfo.get_all();
+monitor.connect("changed", () => {
+  appsCache = Gio.AppInfo.get_all();
+});
+```
+
+Plus a `Map<string, Gio.Icon | null>` memo keyed by `appClass`.
+
+---
+
+### `[ ] C-2.7` Dead try/catch arms around `Gio.ThemedIcon.new()`
+
+**File:** `config/helpers/icon-resolver.tsx:31, 69, 78, 87, 94`
+
+`Gio.ThemedIcon.new()` cannot throw in any current GLib. Remove the
+try/catch arms; control flow becomes obvious.
+
+---
+
+### `[ ] C-2.8` Battery 2 s poll redundant with `notify::*`
+
+**File:** `config/right/battery/battery.tsx:147`
+
+UPower fires `notify::*` for every state change. The poll exists "to
+catch state changes that don't fire events" — workaround for an upstream
+bug.
+
+**Fix:** investigate whether the upstream bug still exists; if yes,
+document which property is missed; if no, drop the poll.
+
+---
+
+### `[ ] C-2.9` Tray-item tooltip captured at construction
+
+**File:** `config/left/sys-tray/tray-item.tsx:129-135`
+
+`attachTooltip(button, { text: () => tooltip, … })` closes over a
+constant `tooltip` resolved once at construction. Tooltip-markup
+property changes at runtime are never reflected.
+
+**Fix:** `text: () => resolveTooltipMarkup(item)`.
+
+---
+
+## 3. Architecture / quality
+
+### `[ ] C-3.1` Centralize VPN + compositor detection
+
+**Files:**
+
+- `config/sidebar/connectivity-toggles.tsx`
+- `config/right/network/network.tsx`
+- `config/sidebar/system-actions.tsx`
+- `config/compositors/index.ts`
+
+Multiple files independently shell `nmcli` and `pgrep`.
+
+**Fix:**
+
+- `config/services/vpn.tsx` — singleton, async monitor (or D-Bus),
+  expose subscribe API.
+
+- `config/services/compositor-detect.tsx` — detect once at module load,
+  cache, expose `getDetectedCompositor(): "hyprland" | "niri" | "sway" | "other"`.
+
+---
+
+### `[ ] C-3.2` `_cleanup` lifecycle is fragile
+
+**Pattern:** widespread.
+
+The `(widget as ... & { _cleanup?: () => void })._cleanup = ...`
+convention is never invoked by GTK. It only fires when `app.tsx`'s
+recursive walker runs (window destroy). Mid-lifetime removals
+(`tray.tsx:30-38`, `media-player.tsx:447-455`) require manual walks
+that some sites do and some don't.
+
+**Fix:** prefer `widget.connect("destroy", cleanup)` — GTK fires this on
+finalize regardless of how the widget left the tree. Keep `_cleanup` as
+a chainable hook, but invoke it from a `destroy` handler so it runs
+universally.
+
+---
+
+### `[ ] C-3.3` Monitor detection via undocumented `(root as { monitor?: number })`
+
+**Files:** `config/center/workspaces.tsx:247`,
+`config/center/window-title.tsx:89`,
+`config/center/active-workspace.tsx:27`
+
+Brittle cast to an undocumented Astal property.
+`compositors/index.ts:113` already exposes `getMonitorConnectorName()`
+which does it the documented way (`get_native → get_surface →
+get_monitor_at_surface → get_connector`).
+
+**Fix:** use `getMonitorConnectorName(box)` everywhere.
+
+---
+
+### `[ ] C-3.4` `clockDrawingAreas.set(c.tzid, ...)` collides on `""`
+
+**File:** `config/right/time-pill/time-pill.tsx:259`
+
+Local clock has `tzid: ""`. Map works today but silently overwrites if
+another empty-tzid clock is added.
+
+**Fix:** key by `c.label`, or assert uniqueness in `CLOCKS`.
+
+---
+
+### `[ ] C-3.5` Pervasive `as unknown as { ... }` casts
+
+**Examples:** `config/sidebar/media-player.tsx:278-282`,
+`config/center/workspaces.tsx:251-253`.
+
+Hides API drift.
+
+**Fix:** generate proper bindings via `generate_types.sh`. Where casts
+remain unavoidable, centralize in `config/helpers/gobject-cast.ts`.
+
+---
+
+### `[ ] C-3.6` Direct `console.{log,error,warn}` everywhere
+
+**Pattern:** widespread.
+
+Long-running journald gets noisy.
+
+**Fix:** add `config/helpers/logger.ts` honoring `AGS_LOG_LEVEL`
+(default `warn`). Mechanical replace.
+
+---
+
+## 4. Quick-wins triage
+
+Rough effort × impact ordering for follow-up PRs:
+
+| ID     | Effort | Impact | Notes                                  |
+| ------ | ------ | ------ | -------------------------------------- |
+| C-1.1  | 1-2 h  | High   | The reason for the audit. Do first.    |
+| C-1.2  | 1 h    | High   | Window titles. Hyprland half is small. |
+| C-2.1  | 30 min | High   | Eliminates 4 Hz baseline churn.        |
+| C-1.3  | 5 min  | Med    | Trivial leak fix.                      |
+| C-1.13 | 15 min | Med    | Sleep-cascade hardening.               |
+| C-2.6  | 30 min | Med    | Visible during previews.               |
+| C-2.2  | 1 h    | Med    | Perceptible smoothness.                |
+| C-2.5  | 2-3 h  | High   | Niri-only; biggest niri perf win.      |
+| C-1.7  | 1 h    | Med    | First-sidebar-open delay vanishes.     |
+
+---
+
+## 5. Out-of-scope but noticed
+
+- `flake.nix` `patchedAgs` override is correct but the deterministic
+  vendorHash needs to be regenerated whenever upstream AGS bumps
+  `cli/go.sum`. Document that in `flake.nix` itself near the override.
+  Not a code bug.
+
+- `CALENDAR_IMPLEMENTATION.md`, `COMPOSITOR_MIGRATION.md`,
+  `CONTRIBUTING.md`, `DDC_SETUP.md`, `NIRI_SUPPORT.md`, `TODO.md` — lots
+  of historical docs at repo root. Consider moving to `docs/`. Not a bug.

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -125,7 +125,7 @@ disconnected in `_cleanup`.
 
 ---
 
-### `[ ] C-1.4` Calendar fetch race on rapid day navigation
+### `[x] C-1.4` Calendar fetch race on rapid day navigation
 
 **File:** `config/right/time-pill/calendar-service.tsx`
 
@@ -138,7 +138,7 @@ to DDC `getvcp` polling in `config/sidebar/sliders.tsx:401-424`.
 
 ---
 
-### `[ ] C-1.5` Network pill: `notify` (no detail) is too broad
+### `[x] C-1.5` Network pill: `notify` (no detail) is too broad
 
 **File:** `config/right/network/network.tsx:201-202, :205-213`
 
@@ -161,7 +161,7 @@ re-shells `nmcli` synchronously on the GTK main thread (line 181 inside
 
 ---
 
-### `[ ] C-1.6` Connectivity-toggles: same nmcli-on-main issue
+### `[x] C-1.6` Connectivity-toggles: same nmcli-on-main issue
 
 **File:** `config/sidebar/connectivity-toggles.tsx:12-35, :308-319`
 
@@ -196,7 +196,7 @@ Lines 397-399 do an `_async` call whose output is discarded; lines
 
 ---
 
-### `[ ] C-1.9` System actions: 3× synchronous `pgrep` per construction
+### `[x] C-1.9` System actions: 3× synchronous `pgrep` per construction
 
 **File:** `config/sidebar/system-actions.tsx:19-46`
 
@@ -457,24 +457,32 @@ property changes at runtime are never reflected.
 
 ## 3. Architecture / quality
 
-### `[ ] C-3.1` Centralize VPN + compositor detection
+### `[x] C-3.1` Centralize VPN + compositor detection
 
-**Files:**
+**Files (refactored):**
 
-- `config/sidebar/connectivity-toggles.tsx`
-- `config/right/network/network.tsx`
-- `config/sidebar/system-actions.tsx`
-- `config/compositors/index.ts`
+- `config/services/vpn.tsx` — new. Singleton-style module: one async
+  nmcli poll (3 s, `Gio.Subprocess`), shared subscribe/unsubscribe API,
+  `toggleVpn()`. Network types `vpn` and `wireguard` both recognised.
+  Poller stops when subscriber count reaches zero; restarts on
+  resubscribe.
+- `config/services/compositor-detect.tsx` — new. Detects compositor
+  identity once at module load: env var first, async `pgrep` fallback
+  via `runAsync`. Exposes `getCompositorKind()` and
+  `getCompositorExitCommand()`.
+- `config/helpers/subprocess.tsx` — new. Houses the shared `runAsync`
+  helper (extracted from `sliders.tsx`) plus a `spawnDetached` wrapper
+  for fire-and-forget commands. All non-blocking by construction.
+- `config/right/network/network.tsx` — drops local `checkVpnStatus`
+  and 3 s `GLib.timeout_add` poll; subscribes to the service.
+- `config/sidebar/connectivity-toggles.tsx` — same. Drops local
+  `checkVpnStatus` and `toggleVpn` helpers.
+- `config/sidebar/system-actions.tsx` — drops the 3× sync `pgrep`
+  detection (resolves C-1.9). Switches to argv arrays + `spawnDetached`.
 
-Multiple files independently shell `nmcli` and `pgrep`.
-
-**Fix:**
-
-- `config/services/vpn.tsx` — singleton, async monitor (or D-Bus),
-  expose subscribe API.
-
-- `config/services/compositor-detect.tsx` — detect once at module load,
-  cache, expose `getDetectedCompositor(): "hyprland" | "niri" | "sway" | "other"`.
+Net effect: zero synchronous `nmcli` / `pgrep` shellings on the GTK
+main thread; one shared 3 s VPN poll instead of two; compositor kind
+resolved exactly once.
 
 ---
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -660,7 +660,7 @@ another empty-tzid clock is added.
 
 ---
 
-### `[ ] C-3.5` Pervasive `as unknown as { ... }` casts
+### `[x] C-3.5` Pervasive `as unknown as { ... }` casts
 
 **Examples:** `config/sidebar/media-player.tsx:278-282`,
 `config/center/workspaces.tsx:251-253`.

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -270,7 +270,7 @@ don't survive widget cleanup robustly. The rest of the codebase uses
 
 ## 2. Memory / performance
 
-### `[ ] C-2.1` `systemState` 250 ms churn
+### `[x] C-2.1` `systemState` 250 ms churn
 
 **File:** `config/right/system/state/modules/system.tsx:19`,
 consumer `config/right/system/state-pill.tsx`

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -105,10 +105,10 @@ requires the adapter to fire the signal. No fire → no update.
   this.hypr.connect("notify::focused-client", rewire);
   ```
 
-- Niri: best fix is `C-2.5` (event-stream). Until then, include title in
-  the polled signature.
+- Niri: replaced wholesale by `C-2.5`; the title-in-signature workaround
+  is gone now that the adapter consumes `WindowOpenedOrChanged` directly.
 
-**Cross-link:** `C-2.5` (niri event-stream) supersedes the niri half.
+**Cross-link:** `C-2.5` (niri event-stream) supersedes the niri half — done.
 
 ---
 
@@ -252,7 +252,8 @@ other.
 **Files:**
 
 - `config/center/workspaces.tsx:214` (`setTimeout`) — handled by C-1.11
-- `config/compositors/niri.ts:283` (`setInterval`) — handled by C-2.5
+- `config/compositors/niri.ts:283` (`setInterval`) — done (C-2.5 replaced
+  the entire poll with an event-stream subscription)
 - `config/right/network/network.tsx:205` (`setInterval`) — done
 - `config/right/battery/battery.tsx:147` (`setInterval`) — done
 
@@ -363,7 +364,7 @@ widget teardown.
 
 ---
 
-### `[ ] C-2.5` Niri adapter: drop polling for event-stream
+### `[x] C-2.5` Niri adapter: drop polling for event-stream
 
 **File:** `config/compositors/niri.ts:283-321`
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -16,7 +16,7 @@ User-facing summary of the two most-felt symptoms today:
 
 ## 1. Correctness bugs
 
-### `[ ] C-1.1` Notifications: missing freedesktop hint handling
+### `[x] C-1.1` Notifications: missing freedesktop hint handling
 
 **File:** `config/services/notifications.tsx:36-62`
 
@@ -56,7 +56,7 @@ appear in the popup only and never enter the persistent history.
 
 ---
 
-### `[ ] C-1.2` Window titles go stale
+### `[x] C-1.2` Window titles go stale
 
 **Files:** `config/compositors/hyprland.ts:120-124`,
 `config/compositors/niri.ts:283-321`,

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -112,7 +112,7 @@ requires the adapter to fire the signal. No fire → no update.
 
 ---
 
-### `[ ] C-1.3` Volume widget: duplicate `notify::default-speaker` handler
+### `[x] C-1.3` Volume widget: duplicate `notify::default-speaker` handler
 
 **File:** `config/right/speaker-volume/volume.tsx:168, :201`
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -451,7 +451,24 @@ document which property is missed; if no, drop the poll.
 constant `tooltip` resolved once at construction. Tooltip-markup
 property changes at runtime are never reflected.
 
-**Fix:** `text: () => resolveTooltipMarkup(item)`.
+**Attempted fix (commit `66eb700`, REVERTED in `0987dc7`):** changed
+to `text: () => resolveTooltipMarkup(item) ?? ""` and dropped the
+`if (tooltip)` gate so every tray button got an `attachTooltip` call.
+This caused intermittent SIGSEGV on tray menu open with
+`GLib-CRITICAL: g_atomic_ref_count_dec: assertion 'old_value > 0'
+failed` and `Gtk-WARNING: While adding page: duplicate child name in
+GtkStack` (DBusMenu items: `Managed devices`, `_VPN Connections`).
+Hypothesis: the unconditional `Gtk.EventControllerMotion` added by
+`attachTooltip` (helpers/tooltip.tsx:146-148) interacts badly with
+`Gtk.PopoverMenu` children on the same button — motion enter/leave
+across the popover boundary triggers tooltip cleanup paths that
+race with the popover's internal stack pages.
+
+**Correct fix (TODO):** keep the `if (tooltip)` construction-time
+gate so items born without a tooltip never get a motion controller.
+Separately, hook `notify::tooltip-markup` / `notify::tooltip` on the
+`AstalTray.TrayItem` to re-invoke `attachTooltip` (or update via a
+property binding) when the underlying SNI emits a tooltip change.
 
 ---
 
@@ -503,7 +520,7 @@ universally.
 
 ---
 
-### `[ ] C-3.3` Monitor detection via undocumented `(root as { monitor?: number })`
+### `[x] C-3.3` Monitor detection via undocumented `(root as { monitor?: number })`
 
 **Files:** `config/center/workspaces.tsx:247`,
 `config/center/window-title.tsx:89`,
@@ -518,7 +535,7 @@ get_monitor_at_surface → get_connector`).
 
 ---
 
-### `[ ] C-3.4` `clockDrawingAreas.set(c.tzid, ...)` collides on `""`
+### `[x] C-3.4` `clockDrawingAreas.set(c.tzid, ...)` collides on `""`
 
 **File:** `config/right/time-pill/time-pill.tsx:259`
 
@@ -541,7 +558,7 @@ remain unavoidable, centralize in `config/helpers/gobject-cast.ts`.
 
 ---
 
-### `[ ] C-3.6` Direct `console.{log,error,warn}` everywhere
+### `[x] C-3.6` Direct `console.{log,error,warn}` everywhere
 
 **Pattern:** widespread.
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -460,7 +460,7 @@ strategy that survives that (test under `G_DEBUG=gc-friendly`).
 
 ---
 
-### `[ ] C-2.3` Multi-monitor popups: per-popup 50 ms timer
+### `[x] C-2.3` Multi-monitor popups: per-popup 50 ms timer
 
 **File:** `config/notifications/popup.tsx:144`,
 `config/notifications/popup-window.tsx`

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -247,16 +247,14 @@ other.
 
 ---
 
-### `[ ] C-1.13` Mixed timer APIs (`setInterval` / `setTimeout` vs `GLib.timeout_add`)
+### `[~] C-1.13` Mixed timer APIs (`setInterval` / `setTimeout` vs `GLib.timeout_add`)
 
 **Files:**
 
-- `config/center/workspaces.tsx:214` (`setTimeout`)
-- `config/sidebar/connectivity-toggles.tsx:205` — actually uses
-  GLib.timeout_add but cross-check
-
-- `config/right/network/network.tsx:205` (`setInterval`)
-- `config/right/battery/battery.tsx:147` (`setInterval`)
+- `config/center/workspaces.tsx:214` (`setTimeout`) — handled by C-1.11
+- `config/compositors/niri.ts:283` (`setInterval`) — handled by C-2.5
+- `config/right/network/network.tsx:205` (`setInterval`) — done
+- `config/right/battery/battery.tsx:147` (`setInterval`) — done
 
 `setInterval`/`setTimeout` are AGS shims. They lack priority control and
 don't survive widget cleanup robustly. The rest of the codebase uses

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -286,6 +286,26 @@ a given tray icon sits.
 
 ---
 
+### `[x] C-1.15` Workspace pill hover oscillation on the left margin
+
+**File:** `config/center/window-workspaces-pill.tsx:42-57`
+
+The pill uses `halign: CENTER`, so when its `Gtk.Revealer` slides open
+the whole box widens _symmetrically_ — its left edge moves left during
+the 180 ms `SLIDE_RIGHT` animation. If the cursor is parked in the few
+pixels between the outer `.window-workspaces` border and the inner
+`.workspaces` pill margin, the relayout briefly moves the box's
+allocated bounds out from under the cursor, firing `leave` →
+`set_reveal_child(false)` → box re-shrinks → cursor re-enters → `enter`
+fires → revealer reopens → loop. Result: visible flicker, sometimes
+permanent stuck-open or stuck-closed state.
+
+**Fix (applied):** treat `leave` as tentative. Schedule the actual
+collapse via `GLib.timeout_add(80ms)`; if `enter` arrives before the
+timer fires, cancel the collapse. Same debounce pattern as C-1.11.
+
+---
+
 ## 2. Memory / performance
 
 ### `[x] C-2.1` `systemState` 250 ms churn

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -173,7 +173,7 @@ Same synchronous `nmcli` shelling pattern. Two files
 
 ---
 
-### `[ ] C-1.7` Sliders: `getDDCMonitors()` blocks on first sidebar open
+### `[x] C-1.7` Sliders: `getDDCMonitors()` blocks on first sidebar open
 
 **File:** `config/sidebar/sliders.tsx:51-125, :681-687`
 
@@ -187,7 +187,7 @@ listener-set so widgets refresh.
 
 ---
 
-### `[ ] C-1.8` Brightness slider: initial DDC fetch fires twice
+### `[x] C-1.8` Brightness slider: initial DDC fetch fires twice
 
 **File:** `config/sidebar/sliders.tsx:397-424`
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -313,7 +313,7 @@ signal/service — wire as event sources and recompute only on change.
 
 ---
 
-### `[ ] C-2.2` Tooltip widget churn on mouse-move
+### `[x] C-2.2` Tooltip widget churn on mouse-move
 
 **File:** `config/helpers/tooltip.tsx:28-79`
 

--- a/config/app.tsx
+++ b/config/app.tsx
@@ -5,6 +5,7 @@ import { Astal } from "ags/gtk4";
 import App from "ags/gtk4/app";
 
 import { WindowWorkspacesPill } from "./center/window-workspaces-pill";
+import { asWindow } from "./helpers/jsx";
 import { createLogger } from "./helpers/logger";
 import { SystemTray } from "./left/sys-tray/tray";
 import {
@@ -58,7 +59,7 @@ function recursiveCleanup(widget: Gtk.Widget | null): void {
 function Bar(monitorIndex: number): Gtk.Window {
   const { TOP, LEFT, RIGHT } = Astal.WindowAnchor;
 
-  const window = (
+  const window = asWindow(
     <window
       name={`fredbar-${monitorIndex}`}
       visible
@@ -88,8 +89,8 @@ function Bar(monitorIndex: number): Gtk.Window {
           <StatePill />
         </box>
       </centerbox>
-    </window>
-  ) as unknown as Gtk.Window;
+    </window>,
+  );
 
   // Ensure all widget cleanup methods are called when window is destroyed
   window.connect("destroy", () => {
@@ -137,23 +138,11 @@ function Bar(monitorIndex: number): Gtk.Window {
 
 /** AGS API compatibility shim */
 function appAddWindow(win: Gtk.Window): void {
-  const anyApp = App as unknown as {
-    addWindow?: (w: Gtk.Window) => void;
-    add_window?: (w: Gtk.Window) => void;
-  };
-
-  anyApp.addWindow?.(win);
-  anyApp.add_window?.(win);
+  App.add_window(win);
 }
 
 function appRemoveWindow(win: Gtk.Window): void {
-  const anyApp = App as unknown as {
-    removeWindow?: (w: Gtk.Window) => void;
-    remove_window?: (w: Gtk.Window) => void;
-  };
-
-  anyApp.removeWindow?.(win);
-  anyApp.remove_window?.(win);
+  App.remove_window(win);
 }
 
 App.start({

--- a/config/app.tsx
+++ b/config/app.tsx
@@ -12,6 +12,7 @@ import { NetworkPill } from "./right/network/network";
 import { VolumePill } from "./right/speaker-volume/volume";
 import { StatePill } from "./right/system/state-pill";
 import { TimePill } from "./right/time-pill/time-pill";
+import { getWindowManager } from "./services/window-manager";
 import { SidebarWindow } from "./sidebar/panel";
 import scss from "./styles/style.scss";
 
@@ -73,7 +74,7 @@ function Bar(monitorIndex: number): Gtk.Window {
           <VolumePill />
           <NetworkPill />
           <BatteryPill />
-          <TimePill />
+          <TimePill monitorIndex={monitorIndex} />
           <StatePill />
         </box>
       </centerbox>
@@ -84,6 +85,32 @@ function Bar(monitorIndex: number): Gtk.Window {
   window.connect("destroy", () => {
     recursiveCleanup(window.get_child());
   });
+
+  // Bar-level click gate (capture phase): any click anywhere inside the bar
+  // window dismisses the currently-open managed panel UNLESS the click target
+  // is inside the widget that owns that panel.
+  //
+  // Why capture phase: it runs before the target widget (e.g. a pill button)
+  // sees the press. We never mark the event handled, so the press still
+  // propagates to whatever widget is under the pointer — pills keep working
+  // normally, and clicks on bar empty-space simply trigger the dismiss
+  // without any other side effect.
+  //
+  // Why "skip if owner": clicking the pill that opened the panel must let
+  // the pill's own toggle handler close it. If we dismissed unconditionally,
+  // the pill's bubble-phase handler would see `visible=false` and re-open it
+  // (toggle paradox). The owner-skip puts the pill in charge of its own
+  // toggle and lets the gate handle every other case.
+  const wm = getWindowManager();
+  const barGate = new Gtk.GestureClick();
+  barGate.set_propagation_phase(Gtk.PropagationPhase.CAPTURE);
+  barGate.connect("pressed", (_gesture, _nPress, x, y) => {
+    if (!wm.getCurrentlyVisible()) return; // nothing to dismiss
+    const target = window.pick(x, y, Gtk.PickFlags.DEFAULT);
+    if (wm.isOwnerOfVisible(target)) return; // pill owns the panel — let it toggle
+    wm.hideAll();
+  });
+  window.add_controller(barGate);
 
   return window;
 }

--- a/config/app.tsx
+++ b/config/app.tsx
@@ -5,6 +5,7 @@ import { Astal } from "ags/gtk4";
 import App from "ags/gtk4/app";
 
 import { WindowWorkspacesPill } from "./center/window-workspaces-pill";
+import { createLogger } from "./helpers/logger";
 import { SystemTray } from "./left/sys-tray/tray";
 import { PopupNotificationWindow } from "./notifications/popup-window";
 import { BatteryPill } from "./right/battery/battery";
@@ -15,6 +16,10 @@ import { TimePill } from "./right/time-pill/time-pill";
 import { getWindowManager } from "./services/window-manager";
 import { SidebarWindow } from "./sidebar/panel";
 import scss from "./styles/style.scss";
+
+const log = createLogger("App");
+
+log.info("fred-bar starting");
 
 App.reset_css();
 
@@ -32,7 +37,7 @@ function recursiveCleanup(widget: Gtk.Widget | null): void {
     try {
       cleanupWidget._cleanup();
     } catch (e) {
-      console.error("Error during widget cleanup:", e);
+      log.error("Error during widget cleanup:", e);
     }
   }
 

--- a/config/app.tsx
+++ b/config/app.tsx
@@ -7,6 +7,11 @@ import App from "ags/gtk4/app";
 import { WindowWorkspacesPill } from "./center/window-workspaces-pill";
 import { createLogger } from "./helpers/logger";
 import { SystemTray } from "./left/sys-tray/tray";
+import {
+  closeOpenTrayPopover,
+  isInsideOpenTrayPopover,
+  isOwnerOfOpenTrayPopover,
+} from "./left/sys-tray/tray-item";
 import { PopupNotificationWindow } from "./notifications/popup-window";
 import { BatteryPill } from "./right/battery/battery";
 import { NetworkPill } from "./right/network/network";
@@ -110,8 +115,18 @@ function Bar(monitorIndex: number): Gtk.Window {
   const barGate = new Gtk.GestureClick();
   barGate.set_propagation_phase(Gtk.PropagationPhase.CAPTURE);
   barGate.connect("pressed", (_gesture, _nPress, x, y) => {
-    if (!wm.getCurrentlyVisible()) return; // nothing to dismiss
     const target = window.pick(x, y, Gtk.PickFlags.DEFAULT);
+
+    // Tray popovers run with autohide:false (so siblings can receive
+    // clicks). Close the open one unless the click landed inside it or
+    // on the tray button that owns it. Skipping owner clicks lets the
+    // button's own toggle handler decide whether to close-and-stop
+    // (same button) or close-and-reopen (different button).
+    if (!isInsideOpenTrayPopover(target) && !isOwnerOfOpenTrayPopover(target)) {
+      closeOpenTrayPopover();
+    }
+
+    if (!wm.getCurrentlyVisible()) return; // nothing else to dismiss
     if (wm.isOwnerOfVisible(target)) return; // pill owns the panel — let it toggle
     wm.hideAll();
   });

--- a/config/center/active-workspace.tsx
+++ b/config/center/active-workspace.tsx
@@ -1,5 +1,5 @@
 import Gtk from "gi://Gtk?version=4.0";
-import { getCompositor } from "compositors";
+import { getCompositor, getMonitorConnectorName } from "compositors";
 
 export function ActiveWorkspace(): Gtk.Label {
   const compositor = getCompositor();
@@ -16,25 +16,13 @@ export function ActiveWorkspace(): Gtk.Label {
     label.set_label(workspace ? String(workspace.name || workspace.id) : "");
   }
 
-  // Get monitor from the window's monitor property
+  // Resolve the monitor connector once the widget is realised. We use the
+  // documented GTK4 path (get_native → get_surface → get_monitor_at_surface
+  // → get_connector) via the shared helper instead of casting `root` to an
+  // undocumented Astal `monitor: number` property.
   label.connect("realize", () => {
-    const root = label.get_root();
-    if (!root) return;
-
-    const display = root.get_display();
-    if (!display) return;
-
-    const monitorProp = (root as unknown as { monitor?: number }).monitor;
-    if (monitorProp === undefined) return;
-
-    const monitors = display.get_monitors();
-    const monitor = monitors.get_item(monitorProp) as unknown as {
-      get_connector?: () => string;
-    } | null;
-    if (monitor) {
-      monitorName = monitor?.get_connector?.() || null;
-      update();
-    }
+    monitorName = getMonitorConnectorName(label);
+    if (monitorName) update();
   });
 
   update();

--- a/config/center/window-title.tsx
+++ b/config/center/window-title.tsx
@@ -1,8 +1,11 @@
 import Gtk from "gi://Gtk?version=4.0";
 import Pango from "gi://Pango?version=1.0";
 
-import { getCompositor } from "compositors";
+import { getCompositor, getMonitorConnectorName } from "compositors";
 import { resolveAppIcon } from "helpers/icon-resolver";
+import { createLogger } from "helpers/logger";
+
+const log = createLogger("WindowTitle");
 
 export function WindowTitle(): Gtk.Box {
   const compositor = getCompositor();
@@ -69,37 +72,13 @@ export function WindowTitle(): Gtk.Box {
   box.append(image);
   box.append(label);
 
-  // Get monitor from the window's monitor property
-  // This is more reliable than surface detection
+  // Resolve the monitor connector once the widget is realised. We use the
+  // documented GTK4 path via the shared helper instead of casting `root` to
+  // an undocumented Astal `monitor: number` property.
   box.connect("realize", () => {
-    const root = box.get_root();
-    if (!root) {
-      console.warn("[WindowTitle] No root window found");
-      return;
-    }
-
-    // Get the window's assigned monitor
-    const display = root.get_display();
-    if (!display) {
-      console.warn("[WindowTitle] No display found");
-      return;
-    }
-
-    // Get monitor index from window property
-    const monitorProp = (root as unknown as { monitor?: number }).monitor;
-    if (monitorProp === undefined) {
-      console.warn("[WindowTitle] No monitor property on window");
-      return;
-    }
-
-    const monitors = display.get_monitors();
-    const monitor = monitors.get_item(monitorProp) as unknown as {
-      get_connector?: () => string;
-    } | null;
-    if (monitor) {
-      monitorName = monitor?.get_connector?.() || null;
-      update();
-    }
+    monitorName = getMonitorConnectorName(box);
+    if (monitorName) update();
+    else log.warn("Could not resolve monitor connector");
   });
 
   update();

--- a/config/center/window-workspaces-pill.tsx
+++ b/config/center/window-workspaces-pill.tsx
@@ -1,3 +1,4 @@
+import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 import { getCompositor } from "compositors";
 import { ActiveWorkspace } from "./active-workspace";
@@ -43,14 +44,44 @@ export function WindowWorkspacesPill(): Gtk.Box {
   if (supportsWorkspaces) {
     const motion = new Gtk.EventControllerMotion();
 
+    /* ----------------------------------------------------------------
+     * Hover-state debounce
+     * ----------------------------------------------------------------
+     * The pill is `halign: CENTER`, so when the revealer expands it
+     * widens the box symmetrically — its left edge slides left during
+     * the 180ms slide animation. If the cursor sits in the few pixels
+     * between the outer pill border and the inner workspace pill, the
+     * relayout can briefly move the box's allocated bounds out from
+     * under the cursor, firing `leave`. That collapses the revealer,
+     * which moves the box right again, putting the cursor back inside,
+     * which re-fires `enter` — an oscillation feedback loop.
+     *
+     * Fix: treat `leave` as tentative. Schedule the actual collapse
+     * 80ms later; if `enter` arrives before then, cancel the collapse.
+     * (See AUDIT C-1.11 for the related popover hover bug.)
+     * -------------------------------------------------------------- */
+    let collapseTimer: number | null = null;
+    const cancelCollapse = () => {
+      if (collapseTimer !== null) {
+        GLib.source_remove(collapseTimer);
+        collapseTimer = null;
+      }
+    };
+
     motion.connect("enter", () => {
+      cancelCollapse();
       activeWs.set_visible(false);
       revealer.set_reveal_child(true);
     });
 
     motion.connect("leave", () => {
-      revealer.set_reveal_child(false);
-      activeWs.set_visible(true);
+      cancelCollapse();
+      collapseTimer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 80, () => {
+        collapseTimer = null;
+        revealer.set_reveal_child(false);
+        activeWs.set_visible(true);
+        return GLib.SOURCE_REMOVE;
+      });
     });
 
     box.add_controller(motion);

--- a/config/center/workspaces.tsx
+++ b/config/center/workspaces.tsx
@@ -1,3 +1,4 @@
+import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 
 import { getCompositor } from "compositors";
@@ -203,34 +204,72 @@ export function Workspaces(): Gtk.Box {
       preview.set_parent(button);
       popovers.push(preview);
 
-      // Show preview on hover
-      const hoverController = new Gtk.EventControllerMotion();
-      let hoverTimeout: number | null = null;
-      let isHovering = false;
+      /* --------------------------------------------------------------
+       * Hover semantics
+       * --------------------------------------------------------------
+       * The cursor must be allowed to leave the button and enter the
+       * popover surface without the popover popping down. We track
+       * "hover state" as a union of (button hovered) ∨ (popover hovered)
+       * and only close after a short grace period during which neither
+       * is hovered. See AUDIT C-1.11.
+       * ------------------------------------------------------------ */
+      let buttonHover = false;
+      let popoverHover = false;
+      let openTimer: number | null = null;
+      let closeTimer: number | null = null;
 
-      hoverController.connect("enter", () => {
-        isHovering = true;
-        // Small delay before showing preview
-        hoverTimeout = setTimeout(() => {
-          if (isHovering) {
-            preview.popup();
-          }
-          hoverTimeout = null;
-        }, 500) as unknown as number;
-      });
-
-      hoverController.connect("leave", () => {
-        isHovering = false;
-        // Clear timeout if we leave before it triggers
-        if (hoverTimeout !== null) {
-          clearTimeout(hoverTimeout);
-          hoverTimeout = null;
+      const cancelOpen = () => {
+        if (openTimer !== null) {
+          GLib.source_remove(openTimer);
+          openTimer = null;
         }
-        // Close immediately when leaving
-        preview.popdown();
-      });
+      };
+      const cancelClose = () => {
+        if (closeTimer !== null) {
+          GLib.source_remove(closeTimer);
+          closeTimer = null;
+        }
+      };
+      const scheduleClose = () => {
+        cancelClose();
+        closeTimer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 120, () => {
+          closeTimer = null;
+          if (!buttonHover && !popoverHover) preview.popdown();
+          return GLib.SOURCE_REMOVE;
+        });
+      };
+      const scheduleOpen = () => {
+        cancelOpen();
+        openTimer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+          openTimer = null;
+          if (buttonHover || popoverHover) preview.popup();
+          return GLib.SOURCE_REMOVE;
+        });
+      };
 
-      button.add_controller(hoverController);
+      const buttonHoverCtl = new Gtk.EventControllerMotion();
+      buttonHoverCtl.connect("enter", () => {
+        buttonHover = true;
+        cancelClose();
+        if (!preview.get_visible()) scheduleOpen();
+      });
+      buttonHoverCtl.connect("leave", () => {
+        buttonHover = false;
+        cancelOpen();
+        scheduleClose();
+      });
+      button.add_controller(buttonHoverCtl);
+
+      const popoverHoverCtl = new Gtk.EventControllerMotion();
+      popoverHoverCtl.connect("enter", () => {
+        popoverHover = true;
+        cancelClose();
+      });
+      popoverHoverCtl.connect("leave", () => {
+        popoverHover = false;
+        scheduleClose();
+      });
+      preview.add_controller(popoverHoverCtl);
 
       box.append(button);
     }

--- a/config/center/workspaces.tsx
+++ b/config/center/workspaces.tsx
@@ -1,7 +1,7 @@
 import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 
-import { getCompositor } from "compositors";
+import { getCompositor, getMonitorConnectorName } from "compositors";
 import { resolveAppIcon } from "helpers/icon-resolver";
 
 /* -----------------------------
@@ -275,25 +275,12 @@ export function Workspaces(): Gtk.Box {
     }
   }
 
-  // Get monitor from the window's monitor property
+  // Resolve the monitor connector once the widget is realised. We use the
+  // documented GTK4 path via the shared helper instead of casting `root` to
+  // an undocumented Astal `monitor: number` property.
   box.connect("realize", () => {
-    const root = box.get_root();
-    if (!root) return;
-
-    const display = root.get_display();
-    if (!display) return;
-
-    const monitorProp = (root as unknown as { monitor?: number }).monitor;
-    if (monitorProp === undefined) return;
-
-    const monitors = display.get_monitors();
-    const monitor = monitors.get_item(monitorProp) as unknown as {
-      get_connector?: () => string;
-    } | null;
-    if (monitor) {
-      monitorName = monitor?.get_connector?.() || null;
-      render();
-    }
+    monitorName = getMonitorConnectorName(box);
+    if (monitorName) render();
   });
 
   render();

--- a/config/compositors/fallback.ts
+++ b/config/compositors/fallback.ts
@@ -1,9 +1,12 @@
+import { createLogger } from "../helpers/logger";
 import type {
   CompositorAdapter,
   CompositorEventHandlers,
   CompositorWindow,
   CompositorWorkspace,
 } from "./types";
+
+const log = createLogger("FallbackAdapter");
 
 /**
  * Fallback compositor adapter
@@ -41,11 +44,11 @@ export class FallbackAdapter implements CompositorAdapter {
   }
 
   switchToWorkspace(_workspaceId: number): void {
-    console.warn("[FallbackAdapter] switchToWorkspace not supported");
+    log.warn("switchToWorkspace not supported");
   }
 
   focusWindow(_address: string): void {
-    console.warn("[FallbackAdapter] focusWindow not supported");
+    log.warn("focusWindow not supported");
   }
 
   connect(_handlers: CompositorEventHandlers): () => void {

--- a/config/compositors/fallback.ts
+++ b/config/compositors/fallback.ts
@@ -39,6 +39,10 @@ export class FallbackAdapter implements CompositorAdapter {
     return null;
   }
 
+  getFocusedMonitor(): string | null {
+    return null;
+  }
+
   getWorkspaceWindows(_workspaceId: number): CompositorWindow[] {
     return [];
   }

--- a/config/compositors/hyprland.ts
+++ b/config/compositors/hyprland.ts
@@ -77,12 +77,9 @@ export class HyprlandAdapter implements CompositorAdapter {
   }
 
   getFocusedMonitor(): string | null {
-    // Hyprland tracks focused monitor on focused_workspace.monitor (a
-    // Hyprland.Monitor object with a `name` string).
+    // Hyprland tracks focused monitor on focused_workspace.monitor.
     const ws = this.hypr.focused_workspace;
-    const monitor = (ws as unknown as { monitor?: { name?: string } } | null)
-      ?.monitor;
-    return monitor?.name ?? null;
+    return ws?.monitor?.name ?? null;
   }
 
   getWorkspaceWindows(workspaceId: number): CompositorWindow[] {

--- a/config/compositors/hyprland.ts
+++ b/config/compositors/hyprland.ts
@@ -60,7 +60,7 @@ export class HyprlandAdapter implements CompositorAdapter {
 
   getFocusedWindow(): CompositorWindow | null {
     const client = this.hypr.focused_client;
-    if (!client || !client.workspace) return null;
+    if (!client?.workspace) return null;
 
     return {
       address: client.address ?? "",

--- a/config/compositors/hyprland.ts
+++ b/config/compositors/hyprland.ts
@@ -92,6 +92,18 @@ export class HyprlandAdapter implements CompositorAdapter {
 
   connect(handlers: CompositorEventHandlers): () => void {
     const connections: number[] = [];
+    // Per-Client title listener bookkeeping. The Hyprland manager does not
+    // emit any signal for in-window title changes; those live on the focused
+    // Client object. We rebind notify::title on each focus change.
+    let trackedClient: Hyprland.Client | null = null;
+    let trackedTitleId: number | null = null;
+    const detachClientListener = (): void => {
+      if (trackedClient && trackedTitleId !== null) {
+        trackedClient.disconnect(trackedTitleId);
+      }
+      trackedClient = null;
+      trackedTitleId = null;
+    };
 
     if (handlers.onWorkspacesChanged) {
       const id = this.hypr.connect(
@@ -110,18 +122,22 @@ export class HyprlandAdapter implements CompositorAdapter {
     }
 
     if (handlers.onFocusedWindowChanged) {
-      const id = this.hypr.connect(
-        "notify::focused-client",
-        handlers.onFocusedWindowChanged,
-      );
+      const fire = handlers.onFocusedWindowChanged;
+      const id = this.hypr.connect("notify::focused-client", () => fire());
       connections.push(id);
 
-      // Also listen for title changes
-      const titleId = this.hypr.connect(
-        "notify::focused-title",
-        handlers.onFocusedWindowChanged,
-      );
-      connections.push(titleId);
+      const rewireTitleListener = (): void => {
+        detachClientListener();
+        trackedClient = this.hypr.focused_client ?? null;
+        trackedTitleId =
+          trackedClient?.connect("notify::title", () => fire()) ?? null;
+      };
+
+      rewireTitleListener();
+      const rewireId = this.hypr.connect("notify::focused-client", () => {
+        rewireTitleListener();
+      });
+      connections.push(rewireId);
     }
 
     if (handlers.onWindowAdded) {
@@ -144,6 +160,7 @@ export class HyprlandAdapter implements CompositorAdapter {
       for (const id of connections) {
         this.hypr.disconnect(id);
       }
+      detachClientListener();
     };
   }
 }

--- a/config/compositors/hyprland.ts
+++ b/config/compositors/hyprland.ts
@@ -76,6 +76,15 @@ export class HyprlandAdapter implements CompositorAdapter {
     return this.getFocusedWindow();
   }
 
+  getFocusedMonitor(): string | null {
+    // Hyprland tracks focused monitor on focused_workspace.monitor (a
+    // Hyprland.Monitor object with a `name` string).
+    const ws = this.hypr.focused_workspace;
+    const monitor = (ws as unknown as { monitor?: { name?: string } } | null)
+      ?.monitor;
+    return monitor?.name ?? null;
+  }
+
   getWorkspaceWindows(workspaceId: number): CompositorWindow[] {
     return this.getWindows().filter(
       (win) => win.workspaceId === workspaceId && !win.hidden,

--- a/config/compositors/index.ts
+++ b/config/compositors/index.ts
@@ -1,9 +1,12 @@
 import GLib from "gi://GLib";
 import type Gtk from "gi://Gtk?version=4.0";
+import { createLogger } from "../helpers/logger";
 import { FallbackAdapter } from "./fallback";
 import { HyprlandAdapter } from "./hyprland";
 import { NiriAdapter } from "./niri";
 import type { CompositorAdapter } from "./types";
+
+const log = createLogger("Compositor");
 
 /**
  * Detect which compositor is currently running
@@ -44,8 +47,8 @@ function detectCompositor(): string {
 
   // If we're on Wayland but don't recognize the compositor
   if (waylandDisplay) {
-    console.warn(
-      `[Compositor] Running on Wayland (${waylandDisplay}) but compositor not recognized`,
+    log.warn(
+      `Running on Wayland (${waylandDisplay}) but compositor not recognized`,
     );
   }
 
@@ -58,18 +61,15 @@ function detectCompositor(): string {
 function createCompositorAdapter(compositorName?: string): CompositorAdapter {
   const name = compositorName ?? detectCompositor();
 
-  console.log(`[Compositor] Initializing adapter for: ${name}`);
+  log.info(`Initializing adapter for: ${name}`);
 
   switch (name) {
     case "hyprland":
       try {
         return new HyprlandAdapter();
       } catch (error) {
-        console.error(
-          "[Compositor] Failed to initialize Hyprland adapter:",
-          error,
-        );
-        console.warn("[Compositor] Falling back to fallback adapter");
+        log.error("Failed to initialize Hyprland adapter:", error);
+        log.warn("Falling back to fallback adapter");
         return new FallbackAdapter();
       }
 
@@ -77,15 +77,13 @@ function createCompositorAdapter(compositorName?: string): CompositorAdapter {
       try {
         return new NiriAdapter();
       } catch (error) {
-        console.error("[Compositor] Failed to initialize Niri adapter:", error);
-        console.warn("[Compositor] Falling back to fallback adapter");
+        log.error("Failed to initialize Niri adapter:", error);
+        log.warn("Falling back to fallback adapter");
         return new FallbackAdapter();
       }
     default:
       if (name !== "fallback") {
-        console.warn(
-          `[Compositor] Unknown compositor '${name}', using fallback adapter`,
-        );
+        log.warn(`Unknown compositor '${name}', using fallback adapter`);
       }
       return new FallbackAdapter();
   }
@@ -127,7 +125,7 @@ export function getMonitorConnectorName(widget: Gtk.Widget): string | null {
     const connector = monitor.get_connector?.();
     return connector || null;
   } catch (error) {
-    console.error("[Compositor] Failed to get monitor connector:", error);
+    log.error("Failed to get monitor connector:", error);
     return null;
   }
 }

--- a/config/compositors/niri.ts
+++ b/config/compositors/niri.ts
@@ -1,3 +1,4 @@
+import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import type {
   CompositorAdapter,
@@ -7,7 +8,7 @@ import type {
 } from "./types";
 
 /**
- * Workspace data from niri JSON output
+ * Workspace data from niri JSON output / event stream.
  */
 interface NiriWorkspaceJson {
   id: number;
@@ -20,10 +21,52 @@ interface NiriWorkspaceJson {
   active_window_id: number | null;
 }
 
+interface NiriWindowJson {
+  id: number;
+  title: string | null;
+  app_id: string | null;
+  workspace_id: number | null;
+  is_focused?: boolean;
+}
+
+/* --------------------------------------------------------------------------
+ * Event payload shapes
+ *
+ * niri emits one JSON object per line on `niri msg --json event-stream`.
+ * Each object has a single key naming the event variant; the value is a
+ * payload object. We type only the fields we use; unknown keys are ignored.
+ * Reference: niri-ipc Event enum.
+ * ------------------------------------------------------------------------ */
+type NiriEvent =
+  | { WorkspacesChanged: { workspaces: NiriWorkspaceJson[] } }
+  | { WorkspaceActivated: { id: number; focused: boolean } }
+  | {
+      WorkspaceActiveWindowChanged: {
+        workspace_id: number;
+        active_window_id: number | null;
+      };
+    }
+  | { WindowsChanged: { windows: NiriWindowJson[] } }
+  | { WindowOpenedOrChanged: { window: NiriWindowJson } }
+  | { WindowClosed: { id: number } }
+  | { WindowFocusChanged: { id: number | null } }
+  | { KeyboardLayoutsChanged: unknown }
+  | { KeyboardLayoutSwitched: unknown }
+  | { OverviewOpenedOrClosed: unknown };
+
 /**
  * Niri compositor adapter
  *
- * Uses `niri msg --json` commands with polling for updates.
+ * Subscribes to `niri msg --json event-stream` once at construction. All
+ * `getWorkspaces`/`getWindows`/`getFocused*` calls become pure reads against
+ * in-process state — no subprocess spawn per call, no 200ms polling. The
+ * stream is consumed line-by-line via Gio.DataInputStream's async API, so
+ * the GTK main loop never blocks on i/o. If the niri socket dies (compositor
+ * restart, niri exit) we reconnect with exponential backoff.
+ *
+ * Action commands (`focus-workspace`, `focus-window`) are still issued via
+ * one-shot async subprocesses — those are write paths that don't produce
+ * events we care about consuming.
  */
 export class NiriAdapter implements CompositorAdapter {
   readonly name = "niri";
@@ -31,25 +74,247 @@ export class NiriAdapter implements CompositorAdapter {
   readonly supportsWindows = true;
 
   private eventHandlers: Array<CompositorEventHandlers> = [];
-  private pollingInterval: number | null = null;
+
+  // In-memory mirror of niri's state. Keyed by id for O(1) updates.
+  private workspaces = new Map<number, NiriWorkspaceJson>();
+  private windows = new Map<number, NiriWindowJson>();
+  private focusedWindowId: number | null = null;
+
+  // Cached focused-output name. WorkspaceActivated{focused:true} updates it
+  // without us having to spawn `niri msg focused-output` ever again after
+  // the initial bootstrap.
+  private focusedOutput: string | null = null;
+
+  // Subprocess + stream handles for the event-stream pipe.
+  private streamProc: Gio.Subprocess | null = null;
+  private streamCancel: Gio.Cancellable | null = null;
+  private streamInput: Gio.DataInputStream | null = null;
+  private reconnectTimeoutId: number | null = null;
+  private reconnectDelayMs = 250;
 
   constructor() {
-    console.log("[NiriAdapter] Initialized with JSON output");
+    // Bootstrap the focused-output name synchronously once. This is the only
+    // remaining spawn_command_line_sync in this adapter and runs at startup
+    // before any UI work, so a few ms of latency here is acceptable.
+    this.focusedOutput = this.getFocusedOutputNameSync();
+    this.startEventStream();
   }
 
-  /**
-   * Get the name of the currently focused output
-   */
-  private getFocusedOutputName(): string | null {
+  /* ------------------------------------------------------------------------
+   * Event stream lifecycle
+   * ---------------------------------------------------------------------- */
+
+  private startEventStream(): void {
+    if (this.streamProc) return;
+
+    let proc: Gio.Subprocess;
+    try {
+      proc = Gio.Subprocess.new(
+        ["niri", "msg", "--json", "event-stream"],
+        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE,
+      );
+    } catch (error) {
+      console.error("[NiriAdapter] Failed to spawn event-stream:", error);
+      this.scheduleReconnect();
+      return;
+    }
+
+    const stdout = proc.get_stdout_pipe();
+    if (!stdout) {
+      console.error("[NiriAdapter] event-stream subprocess has no stdout pipe");
+      proc.force_exit();
+      this.scheduleReconnect();
+      return;
+    }
+
+    const cancel = new Gio.Cancellable();
+    const input = new Gio.DataInputStream({ base_stream: stdout });
+
+    this.streamProc = proc;
+    this.streamCancel = cancel;
+    this.streamInput = input;
+
+    // Reset backoff once the connection is live.
+    this.reconnectDelayMs = 250;
+
+    proc.wait_async(cancel, (_p, _res) => {
+      // The event-stream process exited (niri restart, kill, crash).
+      // Clean up and reconnect — the bar is the long-lived peer here.
+      this.teardownStream();
+      this.scheduleReconnect();
+    });
+
+    this.readNextLine();
+  }
+
+  private readNextLine(): void {
+    const input = this.streamInput;
+    const cancel = this.streamCancel;
+    if (!input || !cancel) return;
+
+    input.read_line_async(GLib.PRIORITY_DEFAULT, cancel, (_stream, res) => {
+      let line: string | null = null;
+      try {
+        const [bytes /*, length */] = input.read_line_finish_utf8(res);
+        line = bytes;
+      } catch (err) {
+        // Cancellation throws here during teardown; ignore. Anything else is
+        // a genuine i/o error and we'll let wait_async drive the reconnect.
+        if (cancel.is_cancelled()) return;
+        console.error("[NiriAdapter] read_line_async error:", err);
+        return;
+      }
+
+      if (line === null) {
+        // EOF: stdout closed. wait_async will fire and reconnect.
+        return;
+      }
+
+      if (line.length > 0) {
+        this.handleEventLine(line);
+      }
+
+      this.readNextLine();
+    });
+  }
+
+  private teardownStream(): void {
+    if (this.streamCancel) {
+      this.streamCancel.cancel();
+    }
+    if (this.streamInput) {
+      try {
+        this.streamInput.close(null);
+      } catch {
+        /* already closed */
+      }
+    }
+    if (this.streamProc) {
+      try {
+        this.streamProc.force_exit();
+      } catch {
+        /* already exited */
+      }
+    }
+    this.streamProc = null;
+    this.streamCancel = null;
+    this.streamInput = null;
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimeoutId !== null) return;
+    const delay = this.reconnectDelayMs;
+    // Exponential backoff capped at 5 s. Reset to 250 ms on successful
+    // connect. This mirrors how every other long-lived event subscriber in
+    // GNOME stack handles a transient peer.
+    this.reconnectDelayMs = Math.min(this.reconnectDelayMs * 2, 5000);
+    this.reconnectTimeoutId = GLib.timeout_add(
+      GLib.PRIORITY_DEFAULT,
+      delay,
+      () => {
+        this.reconnectTimeoutId = null;
+        this.startEventStream();
+        return GLib.SOURCE_REMOVE;
+      },
+    );
+  }
+
+  /* ------------------------------------------------------------------------
+   * Event dispatch
+   * ---------------------------------------------------------------------- */
+
+  private handleEventLine(line: string): void {
+    let parsed: NiriEvent;
+    try {
+      parsed = JSON.parse(line) as NiriEvent;
+    } catch (err) {
+      console.error("[NiriAdapter] Bad event JSON:", err, line);
+      return;
+    }
+
+    // Discriminate on the single key. We accept that some events touch both
+    // workspace and window state and may want to fire multiple handler types.
+    let workspacesDirty = false;
+    let focusedWorkspaceDirty = false;
+    let focusedWindowDirty = false;
+
+    if ("WorkspacesChanged" in parsed) {
+      this.workspaces.clear();
+      for (const ws of parsed.WorkspacesChanged.workspaces) {
+        this.workspaces.set(ws.id, ws);
+        if (ws.is_focused) this.focusedOutput = ws.output;
+      }
+      workspacesDirty = true;
+      focusedWorkspaceDirty = true;
+    } else if ("WorkspaceActivated" in parsed) {
+      const { id, focused } = parsed.WorkspaceActivated;
+      // Update is_active on this workspace and clear it on others on the
+      // same output. is_focused only flips when `focused` is true.
+      const target = this.workspaces.get(id);
+      if (target) {
+        for (const ws of this.workspaces.values()) {
+          if (ws.output === target.output) {
+            ws.is_active = ws.id === id;
+            if (focused) ws.is_focused = ws.id === id;
+          }
+        }
+        if (focused) this.focusedOutput = target.output;
+      }
+      focusedWorkspaceDirty = true;
+    } else if ("WorkspaceActiveWindowChanged" in parsed) {
+      const { workspace_id, active_window_id } =
+        parsed.WorkspaceActiveWindowChanged;
+      const ws = this.workspaces.get(workspace_id);
+      if (ws) ws.active_window_id = active_window_id;
+      focusedWindowDirty = true;
+    } else if ("WindowsChanged" in parsed) {
+      this.windows.clear();
+      for (const w of parsed.WindowsChanged.windows) {
+        this.windows.set(w.id, w);
+        if (w.is_focused) this.focusedWindowId = w.id;
+      }
+      focusedWindowDirty = true;
+    } else if ("WindowOpenedOrChanged" in parsed) {
+      const w = parsed.WindowOpenedOrChanged.window;
+      this.windows.set(w.id, w);
+      if (w.is_focused) this.focusedWindowId = w.id;
+      focusedWindowDirty = true;
+    } else if ("WindowClosed" in parsed) {
+      this.windows.delete(parsed.WindowClosed.id);
+      if (this.focusedWindowId === parsed.WindowClosed.id) {
+        this.focusedWindowId = null;
+      }
+      focusedWindowDirty = true;
+    } else if ("WindowFocusChanged" in parsed) {
+      this.focusedWindowId = parsed.WindowFocusChanged.id;
+      focusedWindowDirty = true;
+    } else {
+      // KeyboardLayoutsChanged / KeyboardLayoutSwitched / OverviewOpenedOrClosed
+      // — not consumed.
+      return;
+    }
+
+    if (workspacesDirty) {
+      for (const h of this.eventHandlers) h.onWorkspacesChanged?.();
+    }
+    if (focusedWorkspaceDirty) {
+      for (const h of this.eventHandlers) h.onFocusedWorkspaceChanged?.();
+    }
+    if (focusedWindowDirty) {
+      for (const h of this.eventHandlers) h.onFocusedWindowChanged?.();
+    }
+  }
+
+  /* ------------------------------------------------------------------------
+   * Bootstrap — only used once at startup
+   * ---------------------------------------------------------------------- */
+
+  private getFocusedOutputNameSync(): string | null {
     try {
       const [success, stdout] = GLib.spawn_command_line_sync(
         "niri msg focused-output",
       );
-
-      if (!success || !stdout) {
-        return null;
-      }
-
+      if (!success || !stdout) return null;
       const output = new TextDecoder().decode(stdout);
       const match = output.match(/Output "[^"]*" \(([^)]+)\)/);
       return match ? match[1] : null;
@@ -59,202 +324,89 @@ export class NiriAdapter implements CompositorAdapter {
     }
   }
 
-  /**
-   * Get all workspaces from JSON output
-   */
-  private getAllWorkspacesJson(): NiriWorkspaceJson[] {
-    try {
-      const [success, stdout] = GLib.spawn_command_line_sync(
-        "niri msg --json workspaces",
-      );
-
-      if (!success || !stdout) {
-        return [];
-      }
-
-      const output = new TextDecoder().decode(stdout);
-      return JSON.parse(output) as NiriWorkspaceJson[];
-    } catch (error) {
-      console.error("[NiriAdapter] Failed to get workspaces JSON:", error);
-      return [];
-    }
-  }
+  /* ------------------------------------------------------------------------
+   * CompositorAdapter — pure reads against in-memory state
+   * ---------------------------------------------------------------------- */
 
   getWorkspaces(monitor?: string): CompositorWorkspace[] {
-    // Use provided monitor or fall back to focused output
-    const targetOutput = monitor || this.getFocusedOutputName();
-    if (!targetOutput) {
-      return [];
-    }
+    const targetOutput = monitor || this.focusedOutput;
+    if (!targetOutput) return [];
 
-    const allWorkspaces = this.getAllWorkspacesJson();
-
-    // Get workspaces for the target output only
     const workspaces: CompositorWorkspace[] = [];
-    for (const ws of allWorkspaces) {
+    for (const ws of this.workspaces.values()) {
       if (ws.output === targetOutput) {
-        workspaces.push({
-          id: ws.id, // Global workspace ID (for matching with windows)
-          name: String(ws.idx), // Display index (1, 2, etc)
-        });
+        workspaces.push({ id: ws.id, name: String(ws.idx) });
       }
     }
-
-    // Sort by display index
-    return workspaces.sort((a, b) => {
+    workspaces.sort((a, b) => {
       const aIdx = parseInt(a.name || "0", 10);
       const bIdx = parseInt(b.name || "0", 10);
       return aIdx - bIdx;
     });
+    return workspaces;
   }
 
   getFocusedWorkspace(monitor?: string): CompositorWorkspace | null {
-    // Use provided monitor or fall back to focused output
-    const targetOutput = monitor || this.getFocusedOutputName();
-    if (!targetOutput) {
-      return null;
-    }
+    const targetOutput = monitor || this.focusedOutput;
+    if (!targetOutput) return null;
 
-    const allWorkspaces = this.getAllWorkspacesJson();
-
-    // Find the active workspace on the target output
-    for (const ws of allWorkspaces) {
+    for (const ws of this.workspaces.values()) {
       if (ws.output === targetOutput && ws.is_active) {
-        return {
-          id: ws.id,
-          name: String(ws.idx),
-        };
+        return { id: ws.id, name: String(ws.idx) };
       }
     }
-
     return null;
   }
 
   getFocusedWindowForMonitor(monitor: string): CompositorWindow | null {
-    const allWorkspaces = this.getAllWorkspacesJson();
-
-    // Find the active workspace on this monitor
-    const activeWorkspace = allWorkspaces.find(
-      (ws) => ws.output === monitor && ws.is_active,
-    );
-
-    if (!activeWorkspace?.active_window_id) {
-      return null;
+    let activeWorkspace: NiriWorkspaceJson | undefined;
+    for (const ws of this.workspaces.values()) {
+      if (ws.output === monitor && ws.is_active) {
+        activeWorkspace = ws;
+        break;
+      }
     }
+    if (!activeWorkspace?.active_window_id) return null;
 
-    // Get the window with this ID (convert number to string for comparison)
-    const windowId = String(activeWorkspace.active_window_id);
-    const windows = this.getWindows();
-    return windows.find((w) => w.address === windowId) || null;
+    const w = this.windows.get(activeWorkspace.active_window_id);
+    return w ? this.toCompositorWindow(w) : null;
   }
 
-  /**
-   * Get all windows from JSON output
-   */
   getWindows(): CompositorWindow[] {
-    try {
-      const [success, stdout] = GLib.spawn_command_line_sync(
-        "niri msg --json windows",
-      );
-
-      if (!success || !stdout) {
-        return [];
-      }
-
-      const output = new TextDecoder().decode(stdout);
-      const windowsJson = JSON.parse(output) as Array<{
-        id: number;
-        title: string | null;
-        app_id: string | null;
-        workspace_id: number | null;
-      }>;
-
-      return windowsJson
-        .filter(
-          (w) => w && w.workspace_id !== null && w.workspace_id !== undefined,
-        )
-        .map((w) => ({
-          address: String(w.id ?? ""),
-          title: w.title ?? "",
-          appClass: w.app_id ?? "",
-          workspaceId: w.workspace_id ?? 0,
-          hidden: false,
-        }));
-    } catch (error) {
-      console.error("[NiriAdapter] Failed to get windows:", error);
-      return [];
+    const out: CompositorWindow[] = [];
+    for (const w of this.windows.values()) {
+      if (w.workspace_id === null || w.workspace_id === undefined) continue;
+      out.push(this.toCompositorWindow(w));
     }
+    return out;
   }
 
   getFocusedWindow(): CompositorWindow | null {
-    try {
-      const [success, stdout] = GLib.spawn_command_line_sync(
-        "niri msg --json focused-window",
-      );
-
-      if (!success || !stdout) {
-        return null;
-      }
-
-      const output = new TextDecoder().decode(stdout).trim();
-
-      // Handle empty response (no focused window)
-      if (!output) {
-        return null;
-      }
-
-      const windowJson = JSON.parse(output) as {
-        id: number;
-        title: string | null;
-        app_id: string | null;
-        workspace_id: number | null;
-      } | null;
-
-      if (
-        !windowJson ||
-        windowJson.workspace_id === null ||
-        windowJson.workspace_id === undefined
-      ) {
-        return null;
-      }
-
-      return {
-        address: String(windowJson.id ?? ""),
-        title: windowJson.title ?? "",
-        appClass: windowJson.app_id ?? "",
-        workspaceId: windowJson.workspace_id,
-        hidden: false,
-      };
-    } catch (error) {
-      console.error("[NiriAdapter] Failed to get focused window:", error);
+    if (this.focusedWindowId === null) return null;
+    const w = this.windows.get(this.focusedWindowId);
+    if (!w || w.workspace_id === null || w.workspace_id === undefined) {
       return null;
     }
+    return this.toCompositorWindow(w);
   }
 
   getWorkspaceWindows(workspaceId: number): CompositorWindow[] {
-    // workspaceId is the global workspace ID
-    return this.getWindows().filter(
-      (win) => win.workspaceId === workspaceId && !win.hidden,
-    );
+    const out: CompositorWindow[] = [];
+    for (const w of this.windows.values()) {
+      if (w.workspace_id === workspaceId) out.push(this.toCompositorWindow(w));
+    }
+    return out;
   }
 
   switchToWorkspace(workspaceId: number): void {
+    const ws = this.workspaces.get(workspaceId);
+    if (!ws) {
+      console.warn(`[NiriAdapter] Workspace ID ${workspaceId} not found`);
+      return;
+    }
     try {
-      // We need to convert the global workspace ID to the index for the current output
-      const focusedOutput = this.getFocusedOutputName();
-      if (!focusedOutput) return;
-
-      const allWorkspaces = this.getAllWorkspacesJson();
-      const targetWorkspace = allWorkspaces.find((ws) => ws.id === workspaceId);
-
-      if (!targetWorkspace) {
-        console.warn(`[NiriAdapter] Workspace ID ${workspaceId} not found`);
-        return;
-      }
-
-      // Use the workspace index for switching
       GLib.spawn_command_line_async(
-        `niri msg action focus-workspace ${targetWorkspace.idx}`,
+        `niri msg action focus-workspace ${ws.idx}`,
       );
     } catch (error) {
       console.error("[NiriAdapter] Failed to switch workspace:", error);
@@ -272,75 +424,24 @@ export class NiriAdapter implements CompositorAdapter {
   }
 
   connect(handlers: CompositorEventHandlers): () => void {
-    // Add handlers to the array instead of merging
     this.eventHandlers.push(handlers);
-
-    // Start polling if not already started
-    if (this.pollingInterval === null) {
-      let lastWorkspaceState = "";
-      let lastActiveWindowsPerMonitor = "";
-
-      this.pollingInterval = setInterval(() => {
-        // Check for workspace changes
-        const workspaces = this.getWorkspaces();
-        const focusedWorkspace = this.getFocusedWorkspace();
-        const currentWorkspaceState = JSON.stringify({
-          workspaces,
-          focused: focusedWorkspace,
-        });
-
-        if (currentWorkspaceState !== lastWorkspaceState) {
-          lastWorkspaceState = currentWorkspaceState;
-          // Call all registered handlers
-          for (const handler of this.eventHandlers) {
-            handler.onWorkspacesChanged?.();
-            handler.onFocusedWorkspaceChanged?.();
-          }
-        }
-
-        // Check for active window changes PER MONITOR
-        const allWorkspaces = this.getAllWorkspacesJson();
-        // Track focused window's title alongside the per-monitor active id so
-        // in-window title changes (browser tab swap, terminal cwd update) also
-        // propagate. Without this, lastActiveWindowsPerMonitor only changes on
-        // window swap and the bar's title widget goes stale.
-        // C-2.5 will replace this poll with the niri event-stream.
-        const focusedTitle = this.getFocusedWindow()?.title ?? "";
-        const activeWindowsPerMonitor = allWorkspaces
-          .filter((ws) => ws.is_active)
-          .map((ws) => ({
-            output: ws.output,
-            windowId: ws.active_window_id,
-          }))
-          .sort((a, b) => a.output.localeCompare(b.output)); // Sort for stable comparison
-        const currentActiveWindowsPerMonitor = JSON.stringify({
-          monitors: activeWindowsPerMonitor,
-          focusedTitle,
-        });
-
-        if (currentActiveWindowsPerMonitor !== lastActiveWindowsPerMonitor) {
-          lastActiveWindowsPerMonitor = currentActiveWindowsPerMonitor;
-          // Call all registered handlers
-          for (const handler of this.eventHandlers) {
-            handler.onFocusedWindowChanged?.();
-          }
-        }
-      }, 200) as unknown as number; // Poll every 200ms
-    }
-
     return () => {
-      // Remove this specific handler from the array
-      const index = this.eventHandlers.indexOf(handlers);
-      if (index > -1) {
-        this.eventHandlers.splice(index, 1);
-      }
+      const i = this.eventHandlers.indexOf(handlers);
+      if (i > -1) this.eventHandlers.splice(i, 1);
+    };
+  }
 
-      if (this.eventHandlers.length === 0) {
-        if (this.pollingInterval !== null) {
-          clearInterval(this.pollingInterval);
-          this.pollingInterval = null;
-        }
-      }
+  /* ------------------------------------------------------------------------
+   * Helpers
+   * ---------------------------------------------------------------------- */
+
+  private toCompositorWindow(w: NiriWindowJson): CompositorWindow {
+    return {
+      address: String(w.id ?? ""),
+      title: w.title ?? "",
+      appClass: w.app_id ?? "",
+      workspaceId: w.workspace_id ?? 0,
+      hidden: false,
     };
   }
 }

--- a/config/compositors/niri.ts
+++ b/config/compositors/niri.ts
@@ -1,11 +1,14 @@
 import Gio from "gi://Gio";
 import GLib from "gi://GLib";
+import { createLogger } from "../helpers/logger";
 import type {
   CompositorAdapter,
   CompositorEventHandlers,
   CompositorWindow,
   CompositorWorkspace,
 } from "./types";
+
+const log = createLogger("NiriAdapter");
 
 /**
  * Workspace data from niri JSON output / event stream.
@@ -114,14 +117,14 @@ export class NiriAdapter implements CompositorAdapter {
         Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE,
       );
     } catch (error) {
-      console.error("[NiriAdapter] Failed to spawn event-stream:", error);
+      log.error("Failed to spawn event-stream:", error);
       this.scheduleReconnect();
       return;
     }
 
     const stdout = proc.get_stdout_pipe();
     if (!stdout) {
-      console.error("[NiriAdapter] event-stream subprocess has no stdout pipe");
+      log.error("event-stream subprocess has no stdout pipe");
       proc.force_exit();
       this.scheduleReconnect();
       return;
@@ -161,7 +164,7 @@ export class NiriAdapter implements CompositorAdapter {
         // Cancellation throws here during teardown; ignore. Anything else is
         // a genuine i/o error and we'll let wait_async drive the reconnect.
         if (cancel.is_cancelled()) return;
-        console.error("[NiriAdapter] read_line_async error:", err);
+        log.error("read_line_async error:", err);
         return;
       }
 
@@ -228,7 +231,7 @@ export class NiriAdapter implements CompositorAdapter {
     try {
       parsed = JSON.parse(line) as NiriEvent;
     } catch (err) {
-      console.error("[NiriAdapter] Bad event JSON:", err, line);
+      log.error("Bad event JSON:", err, line);
       return;
     }
 
@@ -319,7 +322,7 @@ export class NiriAdapter implements CompositorAdapter {
       const match = output.match(/Output "[^"]*" \(([^)]+)\)/);
       return match ? match[1] : null;
     } catch (error) {
-      console.error("[NiriAdapter] Failed to get focused output:", error);
+      log.error("Failed to get focused output:", error);
       return null;
     }
   }
@@ -401,7 +404,7 @@ export class NiriAdapter implements CompositorAdapter {
   switchToWorkspace(workspaceId: number): void {
     const ws = this.workspaces.get(workspaceId);
     if (!ws) {
-      console.warn(`[NiriAdapter] Workspace ID ${workspaceId} not found`);
+      log.warn(`Workspace ID ${workspaceId} not found`);
       return;
     }
     try {
@@ -409,7 +412,7 @@ export class NiriAdapter implements CompositorAdapter {
         `niri msg action focus-workspace ${ws.idx}`,
       );
     } catch (error) {
-      console.error("[NiriAdapter] Failed to switch workspace:", error);
+      log.error("Failed to switch workspace:", error);
     }
   }
 
@@ -419,7 +422,7 @@ export class NiriAdapter implements CompositorAdapter {
         `niri msg action focus-window --id ${address}`,
       );
     } catch (error) {
-      console.error("[NiriAdapter] Failed to focus window:", error);
+      log.error("Failed to focus window:", error);
     }
   }
 

--- a/config/compositors/niri.ts
+++ b/config/compositors/niri.ts
@@ -375,6 +375,10 @@ export class NiriAdapter implements CompositorAdapter {
     return w ? this.toCompositorWindow(w) : null;
   }
 
+  getFocusedMonitor(): string | null {
+    return this.focusedOutput;
+  }
+
   getWindows(): CompositorWindow[] {
     const out: CompositorWindow[] = [];
     for (const w of this.windows.values()) {

--- a/config/compositors/niri.ts
+++ b/config/compositors/niri.ts
@@ -138,7 +138,7 @@ export class NiriAdapter implements CompositorAdapter {
       (ws) => ws.output === monitor && ws.is_active,
     );
 
-    if (!activeWorkspace || !activeWorkspace.active_window_id) {
+    if (!activeWorkspace?.active_window_id) {
       return null;
     }
 

--- a/config/compositors/niri.ts
+++ b/config/compositors/niri.ts
@@ -300,6 +300,12 @@ export class NiriAdapter implements CompositorAdapter {
 
         // Check for active window changes PER MONITOR
         const allWorkspaces = this.getAllWorkspacesJson();
+        // Track focused window's title alongside the per-monitor active id so
+        // in-window title changes (browser tab swap, terminal cwd update) also
+        // propagate. Without this, lastActiveWindowsPerMonitor only changes on
+        // window swap and the bar's title widget goes stale.
+        // C-2.5 will replace this poll with the niri event-stream.
+        const focusedTitle = this.getFocusedWindow()?.title ?? "";
         const activeWindowsPerMonitor = allWorkspaces
           .filter((ws) => ws.is_active)
           .map((ws) => ({
@@ -307,9 +313,10 @@ export class NiriAdapter implements CompositorAdapter {
             windowId: ws.active_window_id,
           }))
           .sort((a, b) => a.output.localeCompare(b.output)); // Sort for stable comparison
-        const currentActiveWindowsPerMonitor = JSON.stringify(
-          activeWindowsPerMonitor,
-        );
+        const currentActiveWindowsPerMonitor = JSON.stringify({
+          monitors: activeWindowsPerMonitor,
+          focusedTitle,
+        });
 
         if (currentActiveWindowsPerMonitor !== lastActiveWindowsPerMonitor) {
           lastActiveWindowsPerMonitor = currentActiveWindowsPerMonitor;

--- a/config/compositors/sway.ts.template
+++ b/config/compositors/sway.ts.template
@@ -292,7 +292,7 @@ export class SwayAdapter implements CompositorAdapter {
           handlers.onFocusedWindowChanged();
         }
       }
-    }, 100) as unknown as number; // Poll every 100ms
+    }, 100); // Poll every 100ms
 
     // Return disconnect function
     return () => {

--- a/config/compositors/types.ts
+++ b/config/compositors/types.ts
@@ -82,6 +82,13 @@ export interface CompositorAdapter {
   getFocusedWindowForMonitor(monitor: string): CompositorWindow | null;
 
   /**
+   * Get the connector name of the currently focused monitor/output.
+   * Returns null if unknown (e.g. fallback adapter, or before bootstrap
+   * completes).
+   */
+  getFocusedMonitor(): string | null;
+
+  /**
    * Get windows for a specific workspace
    */
   getWorkspaceWindows(workspaceId: number): CompositorWindow[];

--- a/config/declarations.d.ts
+++ b/config/declarations.d.ts
@@ -1,4 +1,0 @@
-declare module "*.scss" {
-  const content: string;
-  export default content;
-}

--- a/config/env.d.ts
+++ b/config/env.d.ts
@@ -1,0 +1,21 @@
+declare const SRC: string;
+
+declare module "inline:*" {
+  const content: string;
+  export default content;
+}
+
+declare module "*.scss" {
+  const content: string;
+  export default content;
+}
+
+declare module "*.blp" {
+  const content: string;
+  export default content;
+}
+
+declare module "*.css" {
+  const content: string;
+  export default content;
+}

--- a/config/helpers/backdrop.tsx
+++ b/config/helpers/backdrop.tsx
@@ -4,6 +4,7 @@
 import Gtk from "gi://Gtk?version=4.0";
 import { Astal } from "ags/gtk4";
 import App from "ags/gtk4/app";
+import { asWindow } from "./jsx";
 
 /**
  * Create a transparent backdrop window that closes a target window when clicked
@@ -15,7 +16,7 @@ export function createBackdrop(
 ): Gtk.Window {
   const { TOP, RIGHT, BOTTOM, LEFT } = Astal.WindowAnchor;
 
-  const backdrop = (
+  const backdrop = asWindow(
     <window
       name={`backdrop-${targetWindow.name || "unknown"}`}
       visible={false}
@@ -24,8 +25,8 @@ export function createBackdrop(
       exclusivity={Astal.Exclusivity.NORMAL}
       layer={Astal.Layer.TOP}
       keymode={Astal.Keymode.NONE}
-    />
-  ) as unknown as Gtk.Window;
+    />,
+  );
 
   // Make the backdrop transparent and clickable
   const box = new Gtk.Box({
@@ -49,12 +50,9 @@ export function createBackdrop(
     backdrop.visible = targetWindow.visible;
   });
 
-  // Register with App. AGS' Astal.Application binding exposes `add_window`
-  // (the GIR/GTK name); the camelCase alias is provided by some bindings
-  // but `add_window` is canonical and always present in gtk-4.0.
-  (App as unknown as { add_window: (w: Gtk.Window) => void }).add_window(
-    backdrop,
-  );
+  // Register with App. AGS' Astal.Application extends Gtk.Application
+  // which provides add_window.
+  App.add_window(backdrop);
 
   return backdrop;
 }
@@ -107,7 +105,7 @@ export function createManualBackdrop(
 ): TrayBackdropHandle {
   const { TOP, RIGHT, BOTTOM, LEFT } = Astal.WindowAnchor;
 
-  const backdrop = (
+  const backdrop = asWindow(
     <window
       name="backdrop-tray"
       visible={false}
@@ -117,8 +115,8 @@ export function createManualBackdrop(
       exclusivity={Astal.Exclusivity.NORMAL}
       layer={Astal.Layer.TOP}
       keymode={Astal.Keymode.NONE}
-    />
-  ) as unknown as Gtk.Window;
+    />,
+  );
 
   const box = new Gtk.Box({
     css_classes: ["backdrop-box"],
@@ -133,9 +131,7 @@ export function createManualBackdrop(
   });
   box.add_controller(clickController);
 
-  (App as unknown as { add_window: (w: Gtk.Window) => void }).add_window(
-    backdrop,
-  );
+  App.add_window(backdrop);
 
   return {
     show: () => {

--- a/config/helpers/backdrop.tsx
+++ b/config/helpers/backdrop.tsx
@@ -49,13 +49,12 @@ export function createBackdrop(
     backdrop.visible = targetWindow.visible;
   });
 
-  // Register with App
-  const anyApp = App as unknown as {
-    addWindow?: (w: Gtk.Window) => void;
-    add_window?: (w: Gtk.Window) => void;
-  };
-  anyApp.addWindow?.(backdrop);
-  anyApp.add_window?.(backdrop);
+  // Register with App. AGS' Astal.Application binding exposes `add_window`
+  // (the GIR/GTK name); the camelCase alias is provided by some bindings
+  // but `add_window` is canonical and always present in gtk-4.0.
+  (App as unknown as { add_window: (w: Gtk.Window) => void }).add_window(
+    backdrop,
+  );
 
   return backdrop;
 }

--- a/config/helpers/backdrop.tsx
+++ b/config/helpers/backdrop.tsx
@@ -80,3 +80,69 @@ export function setupBackdrop(
 
   return backdrop;
 }
+
+/**
+ * A backdrop with manual show/hide control, for components whose visibility
+ * isn't tied to a single Gtk.Window — e.g. tray popovers, which are
+ * Gtk.Popover instances parented to a button inside the bar window.
+ *
+ * The backdrop is constrained to a single monitor (by index in the GListModel
+ * from Gdk.Display.get_monitors()). Scoping per-monitor instead of spanning
+ * all outputs is a deliberate trade: a full-screen overlay across every
+ * display has caused input-deadlock recoveries that required SSH-in-to-kill.
+ * A per-monitor backdrop limits blast radius — if anything goes wrong, the
+ * user can move the pointer to another monitor and interact normally.
+ *
+ * Returns a handle the caller can flip when their managed surface opens or
+ * closes.
+ */
+export interface TrayBackdropHandle {
+  show: () => void;
+  hide: () => void;
+}
+
+export function createManualBackdrop(
+  monitorIndex: number,
+  onClose: () => void,
+): TrayBackdropHandle {
+  const { TOP, RIGHT, BOTTOM, LEFT } = Astal.WindowAnchor;
+
+  const backdrop = (
+    <window
+      name="backdrop-tray"
+      visible={false}
+      monitor={monitorIndex}
+      anchor={TOP | RIGHT | BOTTOM | LEFT}
+      class="backdrop-window"
+      exclusivity={Astal.Exclusivity.NORMAL}
+      layer={Astal.Layer.TOP}
+      keymode={Astal.Keymode.NONE}
+    />
+  ) as unknown as Gtk.Window;
+
+  const box = new Gtk.Box({
+    css_classes: ["backdrop-box"],
+    hexpand: true,
+    vexpand: true,
+  });
+  backdrop.set_child(box);
+
+  const clickController = new Gtk.GestureClick();
+  clickController.connect("released", () => {
+    onClose();
+  });
+  box.add_controller(clickController);
+
+  (App as unknown as { add_window: (w: Gtk.Window) => void }).add_window(
+    backdrop,
+  );
+
+  return {
+    show: () => {
+      backdrop.visible = true;
+    },
+    hide: () => {
+      backdrop.visible = false;
+    },
+  };
+}

--- a/config/helpers/cleanup.ts
+++ b/config/helpers/cleanup.ts
@@ -1,0 +1,81 @@
+import type Gtk from "gi://Gtk?version=4.0";
+import { createLogger } from "./logger";
+
+const log = createLogger("Cleanup");
+
+/* -----------------------------
+ * Widget cleanup lifecycle
+ *
+ * The fred-bar code-base uses a `widget._cleanup = () => { ... }` convention
+ * to release per-widget resources (signal handlers, GLib timeouts, service
+ * subscriptions, GIO bindings) that GTK won't free on its own.
+ *
+ * Historically these cleanups only ran when `app.tsx`'s recursiveCleanup
+ * walked the tree (window destroy). Mid-lifetime removals — e.g. a
+ * tray-item being torn down while the bar stays up, or a media-player
+ * player widget being swapped — required manual walks at every removal
+ * site, and were easy to forget.
+ *
+ * This module makes `_cleanup` self-driving: each registered cleanup is
+ * also bound to GTK's `destroy` signal, so it fires automatically whenever
+ * the widget finalises — regardless of whether the recursive walker ran.
+ * The walker stays as a defensive belt-and-suspenders on window destroy
+ * (so e.g. cleanup runs even if a child somehow escapes destroy emission).
+ *
+ * Registrations chain: calling registerCleanup() twice on the same widget
+ * stacks both cleanups (older runs after newer, mirroring the existing
+ * convention in helpers/tooltip.tsx).
+ * ----------------------------- */
+
+export type CleanupFn = () => void;
+type CleanupWidget = Gtk.Widget & {
+  _cleanup?: CleanupFn;
+  _cleanupBound?: boolean;
+};
+
+/**
+ * Register a cleanup callback on a widget. Runs:
+ *   1. when GTK emits "destroy" on the widget (automatic), AND
+ *   2. when something explicitly invokes `widget._cleanup()` (e.g. the
+ *      recursive walker in app.tsx, or a manual removal site).
+ *
+ * The cleanup runs at most once per registration: after invocation the
+ * stored hook is replaced with a no-op, so the destroy signal firing later
+ * doesn't double-fire the same logic.
+ */
+export function registerCleanup(widget: Gtk.Widget, fn: CleanupFn): void {
+  const w = widget as CleanupWidget;
+  const prev = w._cleanup;
+
+  let done = false;
+  const runOnce: CleanupFn = () => {
+    if (done) return;
+    done = true;
+    try {
+      fn();
+    } catch (e) {
+      log.error("cleanup callback threw:", e);
+    }
+    if (prev) {
+      try {
+        prev();
+      } catch (e) {
+        log.error("chained cleanup callback threw:", e);
+      }
+    }
+  };
+
+  w._cleanup = runOnce;
+
+  // Bind to destroy only the first time we register on this widget. Once
+  // bound, the bound handler will invoke whatever `_cleanup` currently
+  // holds — which, thanks to chaining above, is always the most-recent
+  // registration that wraps all previous ones.
+  if (!w._cleanupBound) {
+    w._cleanupBound = true;
+    widget.connect("destroy", () => {
+      const current = (widget as CleanupWidget)._cleanup;
+      if (current) current();
+    });
+  }
+}

--- a/config/helpers/icon-resolver.tsx
+++ b/config/helpers/icon-resolver.tsx
@@ -21,6 +21,37 @@ const ICON_OVERRIDES: Record<string, string> = {
   thunderbird: "thunderbird",
 };
 
+/**
+ * Cached desktop-application list. Gio.AppInfo.get_all() walks
+ * /usr/share/applications and ~/.local/share/applications and is moderately
+ * expensive — calling it on every workspace preview / window-title update /
+ * notification icon resolve was a measurable hot path.
+ *
+ * AppInfoMonitor invalidates the cache when desktop entries are added,
+ * removed, or modified, so the cache is always fresh without polling.
+ */
+let appsCache: Gio.AppInfo[] | null = null;
+const appInfoMonitor = Gio.AppInfoMonitor.get();
+appInfoMonitor.connect("changed", () => {
+  appsCache = null;
+  iconCache.clear();
+});
+
+function getAllAppInfos(): Gio.AppInfo[] {
+  if (appsCache === null) appsCache = Gio.AppInfo.get_all();
+  return appsCache;
+}
+
+/**
+ * Resolved-icon memo keyed by lowercased appClass. Cleared whenever the
+ * AppInfo list changes (see appInfoMonitor handler above).
+ *
+ * `null` is a meaningful cached value — it means "we tried and the desktop
+ * lookup yielded nothing", so callers should fall through to the
+ * ThemedIcon construction path. We therefore use Map<key, value | null>.
+ */
+const iconCache = new Map<string, Gio.Icon | null>();
+
 export function resolveAppIcon(appClass?: string): Gio.Icon | null {
   if (!appClass) return null;
 
@@ -28,74 +59,59 @@ export function resolveAppIcon(appClass?: string): Gio.Icon | null {
 
   // 1️⃣ Check manual overrides first
   if (ICON_OVERRIDES[classLower]) {
-    try {
-      return Gio.ThemedIcon.new(ICON_OVERRIDES[classLower]);
-    } catch {
-      // Continue to other methods
+    return Gio.ThemedIcon.new(ICON_OVERRIDES[classLower]);
+  }
+
+  // 2️⃣ Try exact match with desktop files (cached)
+  if (iconCache.has(classLower)) {
+    const cached = iconCache.get(classLower);
+    if (cached) return cached;
+  } else {
+    const allApps = getAllAppInfos();
+
+    // Try exact ID match
+    let appInfo = allApps.find(
+      (app) => app.get_id()?.toLowerCase() === `${classLower}.desktop`,
+    );
+
+    // Try contains match
+    if (!appInfo) {
+      appInfo = allApps.find((app) =>
+        app.get_id()?.toLowerCase().includes(classLower),
+      );
     }
-  }
 
-  // 2️⃣ Try exact match with desktop files
-  const allApps = Gio.AppInfo.get_all();
+    // Try reverse domain match (e.g., "dev.zed.Zed" -> "zed")
+    if (!appInfo && appClass.includes(".")) {
+      const parts = appClass.split(".");
+      const simpleName = parts[parts.length - 1].toLowerCase();
+      appInfo = allApps.find((app) =>
+        app.get_id()?.toLowerCase().includes(simpleName),
+      );
+    }
 
-  // Try exact ID match
-  let appInfo = allApps.find(
-    (app) => app.get_id()?.toLowerCase() === `${classLower}.desktop`,
-  );
-
-  // Try contains match
-  if (!appInfo) {
-    appInfo = allApps.find((app) =>
-      app.get_id()?.toLowerCase().includes(classLower),
-    );
-  }
-
-  // Try reverse domain match (e.g., "dev.zed.Zed" -> "zed")
-  if (!appInfo && appClass.includes(".")) {
-    const parts = appClass.split(".");
-    const simpleName = parts[parts.length - 1].toLowerCase();
-    appInfo = allApps.find((app) =>
-      app.get_id()?.toLowerCase().includes(simpleName),
-    );
-  }
-
-  if (appInfo) {
-    const icon = appInfo.get_icon();
+    const icon = appInfo?.get_icon() ?? null;
+    iconCache.set(classLower, icon);
     if (icon) return icon;
   }
 
-  // 3️⃣ Try class name as icon name (lowercase)
-  try {
-    return Gio.ThemedIcon.new(classLower);
-  } catch {
-    // Continue
-  }
-
-  // 4️⃣ Try just the last part of reverse domain
+  // 3️⃣ ThemedIcon fallback chain. Gio.ThemedIcon.new_from_names() builds a
+  // single GIcon carrying multiple candidate names; GTK tries each at render
+  // time and uses the first that resolves in the active theme. The previous
+  // implementation called Gio.ThemedIcon.new() per candidate inside try/catch
+  // arms — but ThemedIcon.new is infallible (it never inspects the theme),
+  // so only the first candidate was ever returned and the fallbacks were
+  // dead code. Using new_from_names restores the intended fallback chain.
+  const candidates: string[] = [classLower];
   if (appClass.includes(".")) {
     const parts = appClass.split(".");
-    const lastName = parts[parts.length - 1].toLowerCase();
-    try {
-      return Gio.ThemedIcon.new(lastName);
-    } catch {
-      // Continue
-    }
+    candidates.push(parts[parts.length - 1].toLowerCase());
   }
-
-  // 5️⃣ Try hyphenated version
   const hyphenated = classLower.replace(/\s+/g, "-");
-  try {
-    return Gio.ThemedIcon.new(hyphenated);
-  } catch {
-    // Continue
-  }
+  if (hyphenated !== classLower) candidates.push(hyphenated);
+  candidates.push("application-x-executable");
 
-  // 6️⃣ Fallback to generic application icon
-  try {
-    return Gio.ThemedIcon.new("application-x-executable");
-  } catch {
-    return null;
-  }
+  return Gio.ThemedIcon.new_from_names(candidates);
 }
 
 /**
@@ -156,12 +172,9 @@ export function resolveNotificationIcon(
       if (fileIcon) return fileIcon;
     }
 
-    // Check if it's an icon name
-    try {
-      return Gio.ThemedIcon.new(customImage);
-    } catch (_e) {
-      // Continue to fallback
-    }
+    // Check if it's an icon name. Gio.ThemedIcon.new is infallible — the
+    // previous try/catch was dead code.
+    return Gio.ThemedIcon.new(customImage);
   }
 
   // 2️⃣ Check if appIcon is a file path (notify-send -i /path/to/image.png)

--- a/config/helpers/jsx.ts
+++ b/config/helpers/jsx.ts
@@ -1,0 +1,18 @@
+// jsx.ts
+// Helpers that bridge gnim's JSX inference with concrete Gtk widget types.
+//
+// gnim's `<window>...</window>` JSX expression is typed as `Object` (the GJS
+// base class) rather than `Gtk.Window`, even though it instantiates a Window
+// at runtime. Tightening the JSX runtime types is upstream work; until then
+// `asWindow(<window .../>)` provides a single, documented place where the
+// double-cast lives instead of scattering `as unknown as Gtk.Window` across
+// every site that creates a window.
+import type Gtk from "gi://Gtk?version=4.0";
+
+/**
+ * Coerce a JSX-built `<window>` expression to its true `Gtk.Window` type.
+ * Use this at every JSX window-construction site instead of casting inline.
+ */
+export function asWindow(jsx: object): Gtk.Window {
+  return jsx as unknown as Gtk.Window;
+}

--- a/config/helpers/logger.ts
+++ b/config/helpers/logger.ts
@@ -1,0 +1,85 @@
+// Tiny tagged logger with a single global level threshold.
+//
+// Why this exists: prior to this module every site reached for `console.*`
+// directly, with ad-hoc tag prefixes (`[NiriAdapter]`, `[Compositor]`,
+// some with no prefix at all). On long-running journald sessions the noise
+// adds up, and there was no way to turn it down without a code edit.
+//
+// Configuration: read `AGS_LOG_LEVEL` once at module load. Recognised
+// values are `debug`, `info`, `warn`, `error`, `silent`. Default is `warn`,
+// so info/debug calls are no-ops in production while errors and warnings
+// still surface.
+//
+// Output channels: `warn` → `console.warn` (LEVEL_WARNING), `error` →
+// `console.error` (LEVEL_CRITICAL). Both are visible to gjs's default
+// stderr handler. `info` and `debug` go through `console.log`
+// (LEVEL_MESSAGE) — gjs's default GLib log handler suppresses
+// LEVEL_INFO/LEVEL_DEBUG entirely unless `G_MESSAGES_DEBUG=all`, which
+// would make AGS_LOG_LEVEL a no-op. Routing info/debug through `log`
+// surfaces them when the user opts in via AGS_LOG_LEVEL, which is the
+// real authority. The terminal/journald sees a uniform `Gjs-Console-Message`
+// prefix; if you need to distinguish severity, filter on the `[Tag]`.
+//
+// Usage:
+//   const log = createLogger("NiriAdapter");
+//   log.debug("event-stream connected");
+//   log.warn("workspace ID %d not found", id);
+//   log.error("subprocess failed:", err);
+
+import GLib from "gi://GLib";
+
+const LEVELS = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  silent: 100,
+} as const;
+
+type LevelName = keyof typeof LEVELS;
+
+function parseLevel(raw: string | null | undefined): LevelName {
+  if (!raw) return "warn";
+  const lower = raw.toLowerCase().trim();
+  if (lower in LEVELS) return lower as LevelName;
+  return "warn";
+}
+
+const threshold = LEVELS[parseLevel(GLib.getenv("AGS_LOG_LEVEL"))];
+
+export interface Logger {
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+const NOOP: (...args: unknown[]) => void = () => {};
+
+/**
+ * Create a tagged logger. The tag is wrapped in brackets and prefixed to
+ * every message — e.g. `createLogger("NiriAdapter")` produces output like
+ * `[NiriAdapter] event-stream connected`. Methods below the configured
+ * threshold collapse to a no-op so they cost nothing on the hot path.
+ */
+export function createLogger(tag: string): Logger {
+  const prefix = `[${tag}]`;
+  return {
+    debug:
+      threshold <= LEVELS.debug
+        ? (...args) => console.log(prefix, ...args)
+        : NOOP,
+    info:
+      threshold <= LEVELS.info
+        ? (...args) => console.log(prefix, ...args)
+        : NOOP,
+    warn:
+      threshold <= LEVELS.warn
+        ? (...args) => console.warn(prefix, ...args)
+        : NOOP,
+    error:
+      threshold <= LEVELS.error
+        ? (...args) => console.error(prefix, ...args)
+        : NOOP,
+  };
+}

--- a/config/helpers/subprocess.tsx
+++ b/config/helpers/subprocess.tsx
@@ -1,0 +1,54 @@
+import Gio from "gi://Gio";
+
+/**
+ * Run a shell command without blocking the GTK main loop and resolve with
+ * the captured stdout. We use Gio.Subprocess (the GLib-blessed async-IO
+ * primitive) so the result lands on the main thread via the GLib MainContext
+ * — no manual `idle_add` plumbing required.
+ *
+ * Errors and non-zero exits resolve to `null` rather than rejecting; callers
+ * uniformly want "if it didn't work, fall through" semantics, and we'd
+ * otherwise need a try/catch at every call site.
+ */
+export function runAsync(argv: string[]): Promise<string | null> {
+  return new Promise((resolve) => {
+    let proc: Gio.Subprocess;
+    try {
+      proc = Gio.Subprocess.new(
+        argv,
+        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE,
+      );
+    } catch {
+      resolve(null);
+      return;
+    }
+
+    proc.communicate_utf8_async(null, null, (_p, res) => {
+      try {
+        const [success, stdout] = proc.communicate_utf8_finish(res);
+        if (!success || !proc.get_successful()) {
+          resolve(null);
+          return;
+        }
+        resolve(stdout ?? null);
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+}
+
+/**
+ * Fire-and-forget command spawn that doesn't block the main loop and
+ * doesn't capture output. Use for action commands (e.g. `nmcli connection
+ * up`, `systemctl reboot`, compositor exit). Logs spawn-time failures to
+ * console; runtime failures of the spawned process are not observable
+ * (by design — same as `g_spawn_async`).
+ */
+export function spawnDetached(argv: string[]): void {
+  try {
+    Gio.Subprocess.new(argv, Gio.SubprocessFlags.NONE);
+  } catch (e) {
+    console.error("spawnDetached failed:", argv.join(" "), e);
+  }
+}

--- a/config/helpers/subprocess.tsx
+++ b/config/helpers/subprocess.tsx
@@ -1,4 +1,7 @@
 import Gio from "gi://Gio";
+import { createLogger } from "./logger";
+
+const log = createLogger("Subprocess");
 
 /**
  * Run a shell command without blocking the GTK main loop and resolve with
@@ -49,6 +52,6 @@ export function spawnDetached(argv: string[]): void {
   try {
     Gio.Subprocess.new(argv, Gio.SubprocessFlags.NONE);
   } catch (e) {
-    console.error("spawnDetached failed:", argv.join(" "), e);
+    log.error("spawnDetached failed:", argv.join(" "), e);
   }
 }

--- a/config/helpers/tooltip.tsx
+++ b/config/helpers/tooltip.tsx
@@ -113,13 +113,14 @@ export function attachTooltip(anchor: Gtk.Widget, opts: TooltipOptions): void {
       // a SOURCE_CONTINUE timer reschedules from its *last* fire time, so after
       // a long sleep GLib would rapid-fire many callbacks before the event loop
       // can handle any input. With SOURCE_REMOVE we always reschedule from *now*.
-      if (opts.updateInterval && opts.updateInterval > 0) {
+      const interval = opts.updateInterval;
+      if (interval && interval > 0) {
         cleanupTimeout();
 
         const scheduleTooltipUpdate = () => {
           updateTimeoutId = GLib.timeout_add(
             GLib.PRIORITY_DEFAULT,
-            opts.updateInterval!,
+            interval,
             () => {
               updateTimeoutId = null;
               if (cachedLabel) {

--- a/config/helpers/tooltip.tsx
+++ b/config/helpers/tooltip.tsx
@@ -1,7 +1,6 @@
 import GLib from "gi://GLib?version=2.0";
 import Gtk from "gi://Gtk?version=4.0";
-
-type CleanupWidget = Gtk.Widget & { _cleanup?: () => void };
+import { registerCleanup } from "./cleanup";
 
 interface TooltipOptions {
   text: () => string;
@@ -154,21 +153,18 @@ export function attachTooltip(anchor: Gtk.Widget, opts: TooltipOptions): void {
     }
   });
 
-  // Cleanup chaining
-  (anchor as CleanupWidget)._cleanup = (() => {
-    const prev = (anchor as CleanupWidget)._cleanup;
-    return () => {
-      cleanupTimeout();
-      anchor.disconnect(handlerId);
-      anchor.disconnect(tooltipNotifyHandler);
-      // Drop our cached refs so GC can reclaim the widgets once the
-      // GtkTooltip releases them. We don't unparent — the tooltip owns
-      // the tree after set_custom() and will tear it down on its own
-      // lifecycle when the anchor is destroyed.
-      cachedFrame = null;
-      cachedLabel = null;
-      cachedClasses = [];
-      prev?.();
-    };
-  })();
+  // Cleanup. registerCleanup chains multiple registrations on the same
+  // widget, so callers that registerCleanup() themselves still run after us.
+  registerCleanup(anchor, () => {
+    cleanupTimeout();
+    anchor.disconnect(handlerId);
+    anchor.disconnect(tooltipNotifyHandler);
+    // Drop our cached refs so GC can reclaim the widgets once the
+    // GtkTooltip releases them. We don't unparent — the tooltip owns
+    // the tree after set_custom() and will tear it down on its own
+    // lifecycle when the anchor is destroyed.
+    cachedFrame = null;
+    cachedLabel = null;
+    cachedClasses = [];
+  });
 }

--- a/config/helpers/tooltip.tsx
+++ b/config/helpers/tooltip.tsx
@@ -12,7 +12,21 @@ interface TooltipOptions {
 export function attachTooltip(anchor: Gtk.Widget, opts: TooltipOptions): void {
   anchor.has_tooltip = true;
 
-  let currentLabel: Gtk.Label | null = null;
+  // Cached tooltip widget tree. GTK fires `query-tooltip` on every mouse-move
+  // event while a widget has has_tooltip=true (and on the periodic re-query
+  // it does for keyboard-triggered tooltips). The previous implementation
+  // allocated a fresh Frame + Box + Label on every callback — visible as
+  // jank when sliding the mouse across the bar. We build the tree once on
+  // first show and only update the label text on subsequent queries.
+  //
+  // The cached widgets are owned by the GtkTooltip via set_custom(), which
+  // reparents them; calling set_custom(frame) again with the same instance
+  // is a no-op-ish reparent that GTK handles cleanly. The css class list
+  // is recomputed each query because callers (e.g. battery, network) can
+  // change `classes()` based on state.
+  let cachedFrame: Gtk.Frame | null = null;
+  let cachedLabel: Gtk.Label | null = null;
+  let cachedClasses: string[] = [];
   let updateTimeoutId: number | null = null;
 
   // Helper to clean up the update timeout
@@ -21,10 +35,33 @@ export function attachTooltip(anchor: Gtk.Widget, opts: TooltipOptions): void {
       GLib.source_remove(updateTimeoutId);
       updateTimeoutId = null;
     }
-    currentLabel = null;
   };
 
-  // FIXME: Cache because we have to regenerate this a fair bit on mouse move
+  // Compute the desired css class list from the user-supplied callback.
+  // Mirrors the original branch logic so visuals are unchanged.
+  const computeClasses = (): string[] => {
+    const cls = opts.classes?.();
+    if (!cls) return ["state-idle-tooltip"];
+    const list = Array.isArray(cls) ? cls : [cls];
+    if (list.length === 0) return ["state-idle-tooltip"];
+    return list.map((c) => `${c}-tooltip`);
+  };
+
+  // Apply a class list to the frame, diffing against the previous list so
+  // we only touch GTK when something actually changed (add_css_class /
+  // remove_css_class each take the style-context lock).
+  const applyClasses = (frame: Gtk.Frame, next: string[]): void => {
+    if (
+      cachedClasses.length === next.length &&
+      cachedClasses.every((c, i) => c === next[i])
+    ) {
+      return;
+    }
+    for (const c of cachedClasses) frame.remove_css_class(c);
+    for (const c of next) frame.add_css_class(c);
+    cachedClasses = next;
+  };
+
   const handlerId = anchor.connect(
     "query-tooltip",
     (
@@ -41,42 +78,34 @@ export function attachTooltip(anchor: Gtk.Widget, opts: TooltipOptions): void {
         return false;
       }
 
-      // --- CREATE FRESH WIDGETS EVERY TIME ---
-      const label = new Gtk.Label({
-        label: text,
-        wrap: true,
-        xalign: 0,
-        use_markup: true,
-      });
+      // Build the widget tree on first show, reuse it thereafter.
+      if (!cachedFrame || !cachedLabel) {
+        const label = new Gtk.Label({
+          label: text,
+          wrap: true,
+          xalign: 0,
+          use_markup: true,
+        });
 
-      currentLabel = label;
+        const body = new Gtk.Box({
+          orientation: Gtk.Orientation.VERTICAL,
+          css_classes: ["tooltip-body"],
+        });
+        body.append(label);
 
-      const body = new Gtk.Box({
-        orientation: Gtk.Orientation.VERTICAL,
-        css_classes: ["tooltip-body"],
-      });
-      body.append(label);
+        const frame = new Gtk.Frame({
+          css_classes: ["tooltip-frame"],
+        });
+        frame.set_child(body);
 
-      const frame = new Gtk.Frame({
-        css_classes: ["tooltip-frame"],
-      });
-
-      const cls = opts.classes?.();
-      if (cls) {
-        const list = Array.isArray(cls) ? cls : [cls];
-        if (list.length === 0) {
-          frame.add_css_class("state-idle-tooltip");
-        } else {
-          for (const c of list) {
-            frame.add_css_class(`${c}-tooltip`);
-          }
-        }
-      } else {
-        frame.add_css_class("state-idle-tooltip");
+        cachedFrame = frame;
+        cachedLabel = label;
+      } else if (cachedLabel.get_label() !== text) {
+        cachedLabel.set_label(text);
       }
 
-      frame.set_child(body);
-      tooltip.set_custom(frame);
+      applyClasses(cachedFrame, computeClasses());
+      tooltip.set_custom(cachedFrame);
 
       // Set up live updating if interval is specified.
       // Uses self-scheduling (SOURCE_REMOVE + manual reschedule) rather than
@@ -85,9 +114,7 @@ export function attachTooltip(anchor: Gtk.Widget, opts: TooltipOptions): void {
       // a long sleep GLib would rapid-fire many callbacks before the event loop
       // can handle any input. With SOURCE_REMOVE we always reschedule from *now*.
       if (opts.updateInterval && opts.updateInterval > 0) {
-        if (updateTimeoutId !== null) {
-          GLib.source_remove(updateTimeoutId);
-        }
+        cleanupTimeout();
 
         const scheduleTooltipUpdate = () => {
           updateTimeoutId = GLib.timeout_add(
@@ -95,9 +122,11 @@ export function attachTooltip(anchor: Gtk.Widget, opts: TooltipOptions): void {
             opts.updateInterval!,
             () => {
               updateTimeoutId = null;
-              if (currentLabel) {
+              if (cachedLabel) {
                 const newText = opts.text();
-                currentLabel.set_label(newText);
+                if (cachedLabel.get_label() !== newText) {
+                  cachedLabel.set_label(newText);
+                }
                 scheduleTooltipUpdate();
               }
               return GLib.SOURCE_REMOVE;
@@ -131,6 +160,13 @@ export function attachTooltip(anchor: Gtk.Widget, opts: TooltipOptions): void {
       cleanupTimeout();
       anchor.disconnect(handlerId);
       anchor.disconnect(tooltipNotifyHandler);
+      // Drop our cached refs so GC can reclaim the widgets once the
+      // GtkTooltip releases them. We don't unparent — the tooltip owns
+      // the tree after set_custom() and will tear it down on its own
+      // lifecycle when the anchor is destroyed.
+      cachedFrame = null;
+      cachedLabel = null;
+      cachedClasses = [];
       prev?.();
     };
   })();

--- a/config/left/sys-tray/dbusmenu.tsx
+++ b/config/left/sys-tray/dbusmenu.tsx
@@ -1,0 +1,334 @@
+/**
+ * Direct `com.canonical.dbusmenu` client.
+ *
+ * Why this exists: the appmenu-glib-translator-provided `GMenuModel` and
+ * `GActionGroup` (exposed by AstalTray as `item.menu_model` / `item.action_group`)
+ * are unsafe to read from JS — see `AUDIT.md` C-1.16. The translator borrows
+ * `GVariant` and `GVariantTypeInfo` into the model's attribute table and frees
+ * them mid-walk when it processes a DBus `LayoutUpdated` signal, which causes
+ * a SIGSEGV in `g_variant_type_info_get_type_string` (or
+ * `g_menu_model_real_get_item_attribute_value`, depending on which accessor
+ * we use) under any tray client that updates its menu at runtime
+ * (NetworkManager, mpv, Discord, …).
+ *
+ * Our workaround: bypass the translator entirely. We open a direct D-Bus
+ * channel to the tray application's `com.canonical.dbusmenu` object, call
+ * `GetLayout` ourselves, and immediately `recursiveUnpack()` the reply into
+ * plain JS values. After that call we never touch the source `GVariant`
+ * again, so subsequent translator (or app) mutations cannot affect our
+ * widgets.
+ *
+ * Freshness: dbusmenu servers (notably NetworkManager) rebuild submenu
+ * subtrees with new IDs across short timespans — Wi-Fi rescans tick every
+ * few seconds and re-number every child. Holding IDs from an initial
+ * `GetLayout(0, -1)` and clicking them seconds later yields
+ * "ID does not refer to a menu item we have" errors. We therefore fetch
+ * lazily: root with `depth=1` on popup-open, then each submenu's subtree
+ * with `depth=-1` immediately before opening *that* submenu's popover.
+ *
+ * Spec: https://github.com/AyatanaIndicators/libdbusmenu/blob/master/libdbusmenu-glib/dbus-menu.xml
+ */
+
+import Gio from "gi://Gio";
+import GLib from "gi://GLib";
+import { createLogger } from "helpers/logger";
+
+const log = createLogger("DBusMenu");
+
+const IFACE = "com.canonical.dbusmenu";
+
+/** Properties we want for every menu item. Anything not listed is omitted
+ *  by the server, saving bandwidth and reducing surface for malformed apps. */
+const REQUESTED_PROPS = [
+  "type", // "standard" | "separator"
+  "label", // mnemonic-marked string
+  "enabled", // boolean (default true)
+  "visible", // boolean (default true)
+  "icon-name", // themed icon name
+  "icon-data", // ay (PNG bytes) — we ignore for now, prefer icon-name
+  "toggle-type", // "" | "checkmark" | "radio"
+  "toggle-state", // 0 = off, 1 = on, -1 = indeterminate
+  "children-display", // "" | "submenu"
+  "disposition", // "normal" | "informative" | "warning" | "alert"
+];
+
+/** Decoded menu node. Pure JS data — no GLib pointers retained. */
+export interface MenuNode {
+  id: number;
+  type: "standard" | "separator";
+  label: string;
+  enabled: boolean;
+  visible: boolean;
+  iconName: string | null;
+  toggleType: "" | "checkmark" | "radio";
+  /** 0 = off, 1 = on, -1 = indeterminate. */
+  toggleState: number;
+  hasSubmenu: boolean;
+  children: MenuNode[];
+}
+
+// ---- Variant unpacking -----------------------------------------------------
+
+interface RawLayoutNode extends Array<unknown> {
+  // GetLayout returns layout as `(ia{sv}av)`:
+  //   - i:    id
+  //   - a{sv}: properties
+  //   - av:   children (each child is itself a `v` wrapping `(ia{sv}av)`)
+  // After recursiveUnpack(), tuples become arrays, dicts become plain
+  // objects, and inner variants (`v`) are fully unwrapped so each child
+  // appears directly as another `RawLayoutNode` tuple.
+  0: number;
+  1: Record<string, unknown>;
+  2: RawLayoutNode[];
+}
+
+function asString(v: unknown, fallback = ""): string {
+  return typeof v === "string" ? v : fallback;
+}
+
+function asBool(v: unknown, fallback: boolean): boolean {
+  return typeof v === "boolean" ? v : fallback;
+}
+
+function asNumber(v: unknown, fallback: number): number {
+  return typeof v === "number" ? v : fallback;
+}
+
+function decodeNode(raw: RawLayoutNode): MenuNode {
+  const props = raw[1] ?? {};
+  const type = asString(props.type, "standard");
+  return {
+    id: raw[0],
+    type: type === "separator" ? "separator" : "standard",
+    label: asString(props.label, ""),
+    enabled: asBool(props.enabled, true),
+    visible: asBool(props.visible, true),
+    iconName:
+      typeof props["icon-name"] === "string" &&
+      (props["icon-name"] as string).length > 0
+        ? (props["icon-name"] as string)
+        : null,
+    toggleType:
+      props["toggle-type"] === "checkmark" || props["toggle-type"] === "radio"
+        ? (props["toggle-type"] as "checkmark" | "radio")
+        : "",
+    toggleState: asNumber(props["toggle-state"], -1),
+    hasSubmenu: props["children-display"] === "submenu",
+    children: (raw[2] ?? []).map(decodeNode),
+  };
+}
+
+// ---- Public API ------------------------------------------------------------
+
+function getBus(): Gio.DBusConnection {
+  // `bus_get_sync` returns the (singleton) session bus connection. The first
+  // call connects; subsequent calls just return the cached connection — this
+  // is documented in the glib source and is what every GJS app does in
+  // practice. We avoid the async `bus_get` because its GJS Promise overload
+  // is fragile: depending on gjs version it may bind to the callback overload
+  // and throw "At least 3 arguments required".
+  return Gio.bus_get_sync(Gio.BusType.SESSION, null);
+}
+
+/**
+ * `Gio.DBusConnection.call()` ships both a callback-form and Promise-form
+ * overload in the gir, but at runtime GJS requires the full 10-arg callback
+ * form ("At least 10 arguments required, but only 9 passed"). Wrap it in a
+ * real Promise ourselves rather than relying on gi's coercion.
+ */
+function dbusCall(
+  bus: Gio.DBusConnection,
+  busName: string,
+  objectPath: string,
+  iface: string,
+  method: string,
+  params: GLib.Variant,
+  replyType: GLib.VariantType | null,
+  timeoutMs: number,
+): Promise<GLib.Variant> {
+  return new Promise((resolve, reject) => {
+    bus.call(
+      busName,
+      objectPath,
+      iface,
+      method,
+      params,
+      replyType,
+      Gio.DBusCallFlags.NONE,
+      timeoutMs,
+      null,
+      (src, res) => {
+        try {
+          const reply = (src as Gio.DBusConnection).call_finish(res);
+          resolve(reply);
+        } catch (err) {
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      },
+    );
+  });
+}
+
+/**
+ * Notify the server that the subtree rooted at `parentId` is about to be
+ * shown. Apps that populate their menus lazily (NetworkManager's "Available
+ * Networks", Discord's per-server menus) use this as a signal to scan/fill.
+ * Reply is a bool indicating whether the layout will change; we ignore it
+ * because we always refetch immediately afterward anyway.
+ *
+ * Errors here are non-fatal — many apps reply with a D-Bus error or just
+ * silently do nothing. We log at debug level.
+ */
+export async function aboutToShow(
+  busName: string,
+  objectPath: string,
+  parentId: number,
+): Promise<void> {
+  let bus: Gio.DBusConnection;
+  try {
+    bus = getBus();
+  } catch (err) {
+    log.warn("session bus unavailable:", err);
+    return;
+  }
+  try {
+    await dbusCall(
+      bus,
+      busName,
+      objectPath,
+      IFACE,
+      "AboutToShow",
+      new GLib.Variant("(i)", [parentId]),
+      GLib.VariantType.new("(b)"),
+      2000,
+    );
+  } catch (err) {
+    log.debug(`AboutToShow(${parentId}) failed (non-fatal):`, err);
+  }
+}
+
+/**
+ * Fetch a menu subtree for a tray item.
+ *
+ * - `busName` is the well-known D-Bus name of the tray application (e.g.
+ *   `org.kde.StatusNotifierItem-1234-1`). D-Bus auto-routes to the current
+ *   owner; no need to resolve the unique name ourselves.
+ * - `objectPath` is `item.menu_path`.
+ * - `parentId` is `0` for the root menu, or the id of an interior submenu
+ *   node returned by a previous fetch.
+ * - `depth` is `-1` for "unlimited", `1` for "root + immediate children",
+ *   etc. For volatile menus (NetworkManager's Wi-Fi list rebuilds every
+ *   scan tick) it is critical to refetch with current IDs at submenu-open
+ *   time, otherwise the IDs we send back via `Event(id, "clicked")` will
+ *   reference items the server has already replaced.
+ *
+ * Reply is `recursiveUnpack`-ed immediately into plain JS objects. After
+ * this call returns we never touch the source `GVariant` again — the whole
+ * point of this module (see file header).
+ */
+export async function fetchMenuSubtree(
+  busName: string,
+  objectPath: string,
+  parentId: number,
+  depth: number,
+): Promise<MenuNode | null> {
+  let bus: Gio.DBusConnection;
+  try {
+    bus = getBus();
+  } catch (err) {
+    log.warn("session bus unavailable:", err);
+    return null;
+  }
+
+  // GetLayout(parentId, recursionDepth, propertyNames).
+  // Reply signature: (u(ia{sv}av))  — revision + recursive layout tuple.
+  let reply: GLib.Variant;
+  try {
+    reply = await dbusCall(
+      bus,
+      busName,
+      objectPath,
+      IFACE,
+      "GetLayout",
+      new GLib.Variant("(iias)", [parentId, depth, REQUESTED_PROPS]),
+      GLib.VariantType.new("(u(ia{sv}av))"),
+      5000,
+    );
+  } catch (err) {
+    log.warn(
+      `GetLayout(${parentId},${depth}) failed for ${busName}${objectPath}:`,
+      err,
+    );
+    return null;
+  }
+
+  try {
+    const unpacked = reply.recursiveUnpack() as [number, RawLayoutNode];
+    const root = unpacked[1];
+    return decodeNode(root);
+  } catch (err) {
+    log.warn(`GetLayout reply parse failed for ${busName}${objectPath}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Convenience: `AboutToShow(parentId)` + `fetchMenuSubtree(parentId, depth)`.
+ * The two calls are sequential by design — many apps only repopulate after
+ * receiving the AboutToShow ping, so a parallel `GetLayout` would race and
+ * miss the new content.
+ */
+export async function fetchMenuLayout(
+  busName: string,
+  objectPath: string,
+  parentId = 0,
+  depth = 1,
+): Promise<MenuNode | null> {
+  await aboutToShow(busName, objectPath, parentId);
+  return fetchMenuSubtree(busName, objectPath, parentId, depth);
+}
+
+/**
+ * Send a `clicked` Event to the menu item with the given id. Used for both
+ * leaf activation and toggle/radio rows (the app updates `toggle-state` and
+ * emits `ItemsPropertiesUpdated`; we just refetch next open).
+ *
+ * Per spec, `data` is an arbitrary variant — `clicked` ignores it, so we
+ * send a zero-length string for maximum compatibility. `timestamp` is the
+ * X server timestamp; we don't have one in Wayland, so we send 0 which the
+ * spec says is acceptable.
+ */
+export function sendClicked(
+  busName: string,
+  objectPath: string,
+  id: number,
+): void {
+  void (async (): Promise<void> => {
+    try {
+      const bus = getBus();
+      await dbusCall(
+        bus,
+        busName,
+        objectPath,
+        IFACE,
+        "Event",
+        // Signature: (isvu) = (id, eventId, data, timestamp).
+        new GLib.Variant("(isvu)", [
+          id,
+          "clicked",
+          new GLib.Variant("s", ""),
+          0,
+        ]),
+        null,
+        2000,
+      );
+    } catch (err) {
+      // Common, not worth a warning:
+      //   - "ID does not refer to a menu item we have" — server rebuilt the
+      //     submenu between our GetLayout and this Event. Lazy refetch on
+      //     submenu open makes this rare but not impossible (sub-ms race).
+      //   - app exited, ignored the event, replied with its own error.
+      log.debug(`Event(clicked,${id}) on ${busName}${objectPath} failed:`, err);
+    }
+  })();
+}

--- a/config/left/sys-tray/menu.tsx
+++ b/config/left/sys-tray/menu.tsx
@@ -135,6 +135,14 @@ function buildSubmenuRow(
   busName: string,
   objectPath: string,
   rootClose: () => void,
+  /**
+   * Holder owned by the parent popover. We use it to enforce "only one
+   * submenu open per parent": when a submenu-row is clicked, it closes
+   * whatever submenu the parent is currently showing (if any) before
+   * opening its own. Set to `null` on close so subsequent clicks know
+   * there's no open submenu.
+   */
+  openChildHolder: { popover: Gtk.Popover | null; owner: Gtk.Widget | null },
 ): Gtk.Widget {
   const button = new Gtk.Button({
     css_classes: ["tray-menu-item", "tray-menu-submenu", "flat"],
@@ -158,6 +166,28 @@ function buildSubmenuRow(
 
   button.connect("clicked", () => {
     if (inFlight) return;
+
+    // Toggle: if our submenu is the one currently open, close it.
+    if (openChildHolder.owner === button && openChildHolder.popover) {
+      try {
+        openChildHolder.popover.popdown();
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+
+    // Replace: a different submenu is open — close it first.
+    if (openChildHolder.popover) {
+      try {
+        openChildHolder.popover.popdown();
+      } catch {
+        /* ignore */
+      }
+      openChildHolder.popover = null;
+      openChildHolder.owner = null;
+    }
+
     inFlight = true;
 
     fetchMenuLayout(busName, objectPath, node.id, -1)
@@ -173,8 +203,22 @@ function buildSubmenuRow(
         child.set_parent(button);
         child.set_position(Gtk.PositionType.RIGHT);
         child.set_has_arrow(false);
-        child.set_autohide(true);
+        // Submenus inherit autohide:false from buildPopoverFromNode. Taking
+        // a Wayland popup grab here would consume clicks on sibling tray
+        // buttons (the click would arrive as popup_done on the submenu's
+        // surface, never reaching the other tray button). Outside-the-submenu
+        // dismissal is driven instead by:
+        //   - bar-level capture gate in app.tsx (clicks on the bar)
+        //   - rootClose chain from leaf-row activation (closes ancestors)
+        //   - the parent popover's openChildHolder (clicking another
+        //     submenu-row in the parent closes this one)
+        openChildHolder.popover = child;
+        openChildHolder.owner = button;
         child.connect("closed", () => {
+          if (openChildHolder.popover === child) {
+            openChildHolder.popover = null;
+            openChildHolder.owner = null;
+          }
           GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
             try {
               child.unparent();
@@ -204,11 +248,25 @@ function buildPopoverFromNode(
   objectPath: string,
   rootClose: () => void,
 ): Gtk.Popover {
+  // autohide:false on the root popover so it doesn't take a Wayland popup
+  // grab. With a grab, clicking another tray icon while this menu is open
+  // sends `popup_done` to this surface and *consumes* the click — the second
+  // tray button never sees the press. With autohide:false, the click reaches
+  // the bar normally, and `tray-item.tsx` / bar-level handlers close the
+  // open popover and open the new one. Submenus also inherit this so they
+  // don't shadow sibling tray buttons either.
   const popover = new Gtk.Popover({
     has_arrow: false,
-    autohide: true,
+    autohide: false,
     css_classes: ["tray-menu"],
   });
+
+  // Each popover owns one "open submenu" slot. Submenu rows mutate this to
+  // enforce single-open-per-parent without a Wayland grab. See buildSubmenuRow.
+  const openChildHolder: {
+    popover: Gtk.Popover | null;
+    owner: Gtk.Widget | null;
+  } = { popover: null, owner: null };
 
   const box = new Gtk.Box({
     orientation: Gtk.Orientation.VERTICAL,
@@ -230,7 +288,9 @@ function buildPopoverFromNode(
     }
 
     if (child.hasSubmenu) {
-      box.append(buildSubmenuRow(child, busName, objectPath, rootClose));
+      box.append(
+        buildSubmenuRow(child, busName, objectPath, rootClose, openChildHolder),
+      );
     } else {
       box.append(buildLeafRow(child, busName, objectPath, rootClose));
     }

--- a/config/left/sys-tray/menu.tsx
+++ b/config/left/sys-tray/menu.tsx
@@ -1,0 +1,275 @@
+/**
+ * Hand-rolled tray-menu builder.
+ *
+ * Why this exists: see `./dbusmenu.tsx` and `AUDIT.md` C-1.16. Briefly:
+ * neither `Gtk.PopoverMenu.new_from_model(item.menu_model)` nor a hand-rolled
+ * walk of `item.menu_model` is safe — both crash inside glib when
+ * appmenu-glib-translator mutates the model concurrently (which it does in
+ * response to `LayoutUpdated` DBus signals from the tray app).
+ *
+ * This module builds the popover widget tree from a `MenuNode` produced by
+ * `dbusmenu.fetchMenuLayout()` — pure JS data, no GLib pointers retained.
+ * Click handlers dispatch via `dbusmenu.sendClicked()` over D-Bus directly.
+ */
+
+import GLib from "gi://GLib";
+import Gtk from "gi://Gtk?version=4.0";
+import { fetchMenuLayout, type MenuNode, sendClicked } from "./dbusmenu";
+
+// ---- Helpers ---------------------------------------------------------------
+
+/**
+ * Remove the first un-escaped `_` from a dbusmenu label string (the mnemonic
+ * marker), and collapse `__` → `_` (the literal underscore escape).
+ */
+function stripMnemonic(s: string): string {
+  let out = "";
+  let mnemonicRemoved = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (c === "_") {
+      if (s[i + 1] === "_") {
+        out += "_";
+        i++;
+        continue;
+      }
+      if (!mnemonicRemoved) {
+        mnemonicRemoved = true;
+        continue;
+      }
+    }
+    out += c;
+  }
+  return out;
+}
+
+type TrailingGlyph = "check" | "radio-on" | "radio-off" | "submenu" | null;
+
+function trailingFor(node: MenuNode): TrailingGlyph {
+  if (node.hasSubmenu) return "submenu";
+  if (node.toggleType === "checkmark") {
+    return node.toggleState === 1 ? "check" : null;
+  }
+  if (node.toggleType === "radio") {
+    return node.toggleState === 1 ? "radio-on" : "radio-off";
+  }
+  return null;
+}
+
+function trailingIconName(glyph: Exclude<TrailingGlyph, null>): string {
+  switch (glyph) {
+    case "check":
+      return "object-select-symbolic";
+    case "radio-on":
+      return "radio-checked-symbolic";
+    case "radio-off":
+      return "radio-symbolic";
+    case "submenu":
+      return "go-next-symbolic";
+  }
+}
+
+function makeRowContent(node: MenuNode, glyph: TrailingGlyph): Gtk.Widget {
+  const row = new Gtk.Box({
+    orientation: Gtk.Orientation.HORIZONTAL,
+    spacing: 8,
+    css_classes: ["tray-menu-row"],
+  });
+
+  if (node.iconName) {
+    row.append(
+      new Gtk.Image({
+        icon_name: node.iconName,
+        pixel_size: 16,
+        css_classes: ["tray-menu-icon"],
+      }),
+    );
+  }
+
+  row.append(
+    new Gtk.Label({
+      label: stripMnemonic(node.label),
+      halign: Gtk.Align.START,
+      hexpand: true,
+      css_classes: ["tray-menu-label"],
+    }),
+  );
+
+  if (glyph) {
+    row.append(
+      new Gtk.Image({
+        icon_name: trailingIconName(glyph),
+        pixel_size: 12,
+        css_classes: ["tray-menu-trailing"],
+      }),
+    );
+  }
+
+  return row;
+}
+
+// ---- Widget construction ---------------------------------------------------
+
+function buildLeafRow(
+  node: MenuNode,
+  busName: string,
+  objectPath: string,
+  close: () => void,
+): Gtk.Widget {
+  const button = new Gtk.Button({
+    css_classes: ["tray-menu-item", "flat"],
+    sensitive: node.enabled,
+    child: makeRowContent(node, trailingFor(node)),
+  });
+
+  button.connect("clicked", () => {
+    sendClicked(busName, objectPath, node.id);
+    close();
+  });
+
+  return button;
+}
+
+function buildSubmenuRow(
+  node: MenuNode,
+  busName: string,
+  objectPath: string,
+  rootClose: () => void,
+): Gtk.Widget {
+  const button = new Gtk.Button({
+    css_classes: ["tray-menu-item", "tray-menu-submenu", "flat"],
+    sensitive: node.enabled,
+    child: makeRowContent(node, "submenu"),
+  });
+
+  // We never reuse a child popover: many tray apps (NetworkManager being the
+  // worst offender) rebuild submenu subtrees with fresh IDs every few seconds
+  // as their backend state changes. If we cached the popover from the first
+  // click, the IDs in its rows would be stale by the second open, and
+  // `Event(clicked, id)` would return "ID does not refer to a menu item we
+  // have" — the action would silently do nothing.
+  //
+  // Instead, on every click we:
+  //   1. AboutToShow(node.id)  — let the app populate.
+  //   2. GetLayout(node.id, -1) — fetch the fresh subtree with current IDs.
+  //   3. Build a new popover from the result and pop it up.
+  //   4. On close, unparent on idle (mirrors root-popover lifecycle).
+  let inFlight = false;
+
+  button.connect("clicked", () => {
+    if (inFlight) return;
+    inFlight = true;
+
+    fetchMenuLayout(busName, objectPath, node.id, -1)
+      .then((subtree) => {
+        inFlight = false;
+        if (!subtree) return;
+        const child = buildPopoverFromNode(
+          subtree,
+          busName,
+          objectPath,
+          rootClose,
+        );
+        child.set_parent(button);
+        child.set_position(Gtk.PositionType.RIGHT);
+        child.set_has_arrow(false);
+        child.set_autohide(true);
+        child.connect("closed", () => {
+          GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+            try {
+              child.unparent();
+            } catch {
+              /* ignore */
+            }
+            return GLib.SOURCE_REMOVE;
+          });
+        });
+        child.popup();
+      })
+      .catch(() => {
+        inFlight = false;
+      });
+  });
+
+  return button;
+}
+
+/**
+ * Build a popover containing the children of `parent`. Separators between
+ * children with type=="separator" are rendered as `Gtk.Separator`.
+ */
+function buildPopoverFromNode(
+  parent: MenuNode,
+  busName: string,
+  objectPath: string,
+  rootClose: () => void,
+): Gtk.Popover {
+  const popover = new Gtk.Popover({
+    has_arrow: false,
+    autohide: true,
+    css_classes: ["tray-menu"],
+  });
+
+  const box = new Gtk.Box({
+    orientation: Gtk.Orientation.VERTICAL,
+    spacing: 0,
+    css_classes: ["tray-menu-box"],
+  });
+
+  for (const child of parent.children) {
+    if (!child.visible) continue;
+
+    if (child.type === "separator") {
+      box.append(
+        new Gtk.Separator({
+          orientation: Gtk.Orientation.HORIZONTAL,
+          css_classes: ["tray-menu-separator"],
+        }),
+      );
+      continue;
+    }
+
+    if (child.hasSubmenu) {
+      box.append(buildSubmenuRow(child, busName, objectPath, rootClose));
+    } else {
+      box.append(buildLeafRow(child, busName, objectPath, rootClose));
+    }
+  }
+
+  popover.set_child(box);
+  return popover;
+}
+
+// ---- Public entry point ----------------------------------------------------
+
+/**
+ * Build a fresh tray menu popover from a decoded layout root.
+ *
+ * The popover is unparented; callers must `set_parent()` it before calling
+ * `popup()`. Caller is also responsible for `unparent()` on close (we do
+ * this on idle in `tray-item.tsx`).
+ *
+ * `root` is the top-level `MenuNode` returned by `fetchMenuLayout`. Its
+ * `children` become the rows of the popover; the root node itself is never
+ * rendered.
+ */
+export function buildTrayMenu(
+  root: MenuNode,
+  busName: string,
+  objectPath: string,
+): Gtk.Popover {
+  // Mutable holder to break the cycle: child rows reference `rootClose`,
+  // but `rootClose` needs to refer to the popover we're about to build.
+  const holder: { popover: Gtk.Popover | null } = { popover: null };
+  const rootClose = (): void => {
+    try {
+      holder.popover?.popdown();
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const popover = buildPopoverFromNode(root, busName, objectPath, rootClose);
+  holder.popover = popover;
+  return popover;
+}

--- a/config/left/sys-tray/tray-item.tsx
+++ b/config/left/sys-tray/tray-item.tsx
@@ -1,5 +1,6 @@
 import AstalTray from "gi://AstalTray";
 import Gdk from "gi://Gdk?version=4.0";
+import Gio from "gi://Gio";
 import GObject from "gi://GObject";
 import Gtk from "gi://Gtk?version=4.0";
 import { attachTooltip } from "helpers/tooltip";
@@ -13,6 +14,43 @@ type TrayButton = Gtk.Button & {
 
 // ---- Global "only one popover open" state ----
 let OPEN_POPOVER: Gtk.Popover | null = null;
+
+/**
+ * Walk a menu_model and collect the set of action prefixes referenced by
+ * its items (e.g. `dbusmenu`, `app`, `unity`, `indicator`). The
+ * StatusNotifierItem spec uses `dbusmenu.` exclusively, but in practice
+ * different toolkits emit menus with different prefixes. We register the
+ * action_group only under the prefixes that actually appear, plus
+ * `dbusmenu` as a safety baseline (some bare menus rely on it implicitly).
+ */
+function collectActionPrefixes(model: Gio.MenuModel): Set<string> {
+  const prefixes = new Set<string>(["dbusmenu"]);
+  const visit = (m: Gio.MenuModel): void => {
+    const n = m.get_n_items();
+    for (let i = 0; i < n; i++) {
+      const actionVar = m.get_item_attribute_value(
+        i,
+        Gio.MENU_ATTRIBUTE_ACTION,
+        null,
+      );
+      if (actionVar) {
+        const action = actionVar.get_string()[0];
+        const dot = action.indexOf(".");
+        if (dot > 0) prefixes.add(action.slice(0, dot));
+      }
+      const section = m.get_item_link(i, Gio.MENU_LINK_SECTION);
+      if (section) visit(section);
+      const submenu = m.get_item_link(i, Gio.MENU_LINK_SUBMENU);
+      if (submenu) visit(submenu);
+    }
+  };
+  try {
+    visit(model);
+  } catch (err) {
+    console.warn("Tray menu prefix scan failed:", err);
+  }
+  return prefixes;
+}
 
 function closeOpenPopover(): void {
   if (!OPEN_POPOVER) return;
@@ -45,13 +83,15 @@ function ensurePopover(button: TrayButton, item: TrayItem): Gtk.Popover | null {
     popover.set_position(Gtk.PositionType.BOTTOM);
     popover.add_css_class("tray-menu");
 
-    // Register action group with multiple prefixes to support different tray items
-    // Different apps use different action prefixes (app., unity., indicator., dbusmenu.)
+    // Register the action_group only under prefixes the menu actually
+    // uses. Previously we blanket-registered under dbusmenu/app/unity/
+    // indicator which works but pollutes GTK's action map per item and
+    // makes activation lookups ambiguous. See AUDIT C-1.10.
     if (item.action_group) {
-      popover.insert_action_group("dbusmenu", item.action_group); // dbusmenu. prefix (StatusNotifierItem)
-      popover.insert_action_group("app", item.action_group); // app. prefix
-      popover.insert_action_group("unity", item.action_group); // unity. prefix
-      popover.insert_action_group("indicator", item.action_group); // indicator. prefix
+      const prefixes = collectActionPrefixes(item.menu_model);
+      for (const p of prefixes) {
+        popover.insert_action_group(p, item.action_group);
+      }
     }
 
     popover.connect("closed", () => {

--- a/config/left/sys-tray/tray-item.tsx
+++ b/config/left/sys-tray/tray-item.tsx
@@ -17,32 +17,62 @@ type TrayButton = Gtk.Button & {
   _cleanup?: () => void;
 };
 
-// ---- Global "only one popover open" state ----
+/* ------------------------------------------------------------------
+ * Single-open invariant
+ * ------------------------------------------------------------------
+ * Only one tray popover may be visible at a time. We track it in a
+ * module-global because Wayland popup grabs don't help us here: with
+ * autohide:false (see menu.tsx), the root popover doesn't auto-close on
+ * outside click, so we close it ourselves whenever:
+ *
+ *   1. The user clicks another tray button (handled here).
+ *   2. The user clicks elsewhere on the bar (handled by the bar-level
+ *      capture-phase controller in app.tsx via `closeOpenTrayPopover`).
+ *   3. ESC is pressed while the popover has focus (handled by the
+ *      Gtk.EventControllerKey installed below on each popover).
+ * ------------------------------------------------------------------ */
 let OPEN_POPOVER: Gtk.Popover | null = null;
+let OPEN_OWNER: Gtk.Widget | null = null;
 
-function closeOpenPopover(): void {
+/** Close whatever tray popover is currently open. No-op if none. */
+export function closeOpenTrayPopover(): void {
   if (!OPEN_POPOVER) return;
-
   try {
     OPEN_POPOVER.popdown();
   } catch {
-    // ignore
+    /* ignore */
   }
-
   OPEN_POPOVER = null;
+  OPEN_OWNER = null;
+}
+
+/** Whether `target` is a descendant of the currently-open tray popover. */
+export function isInsideOpenTrayPopover(target: Gtk.Widget | null): boolean {
+  if (!OPEN_POPOVER || !target) return false;
+  let w: Gtk.Widget | null = target;
+  while (w) {
+    if (w === OPEN_POPOVER) return true;
+    w = w.get_parent();
+  }
+  return false;
+}
+
+/** Whether `target` is the tray button that owns the currently-open popover. */
+export function isOwnerOfOpenTrayPopover(target: Gtk.Widget | null): boolean {
+  if (!OPEN_OWNER || !target) return false;
+  let w: Gtk.Widget | null = target;
+  while (w) {
+    if (w === OPEN_OWNER) return true;
+    w = w.get_parent();
+  }
+  return false;
 }
 
 /**
  * Recover the tray app's well-known D-Bus name from `item.item_id`.
  *
  * AstalTray composes `item_id = service + object_path` where `object_path`
- * starts with `/` (e.g. `org.kde.StatusNotifierItem-1234-1/StatusNotifierItem`).
- * Splitting on the first `/` gives us the bus name.
- *
- * We can't use the well-known-vs-unique-name distinction from AstalTray
- * (which uses `proxy.g_name_owner`, the unique `:1.NN` name) — that's not
- * exposed in the gir. The well-known name is fine: D-Bus routes to the
- * current owner automatically.
+ * starts with `/`. Splitting on the first `/` gives us the bus name.
  */
 function busNameFromItemId(itemId: string): string | null {
   const slash = itemId.indexOf("/");
@@ -52,26 +82,21 @@ function busNameFromItemId(itemId: string): string | null {
 
 /** Read the unintrospectable `menu_path` property at runtime. */
 function menuObjectPath(item: TrayItem): string | null {
-  // `menu_path` is typed `never` in the gir because it's `ObjectPath`, but
-  // at runtime it's a plain string (or null). Cast through `unknown`.
   const raw = (item as unknown as { menu_path?: string | null }).menu_path;
   return typeof raw === "string" && raw.startsWith("/") ? raw : null;
 }
 
 /**
  * Open the tray menu for `item`. Fetches layout over D-Bus, builds the
- * popover, and pops it up.
- *
- * Fetching is async (~ms over the session bus), so the popover appears
- * slightly after the click. We intentionally don't pre-fetch: the freshest
- * layout is the one the user expects.
+ * popover, and pops it up. Fetching is async (~ms); we close any
+ * already-open popover first, then again right before showing (in case
+ * another opened during the fetch window).
  */
 function popupMenu(button: TrayButton, item: TrayItem): void {
-  closeOpenPopover();
+  closeOpenTrayPopover();
 
   const busName = busNameFromItemId(item.item_id);
   const objectPath = menuObjectPath(item);
-
   if (!busName || !objectPath) {
     log.debug(`no dbusmenu coordinates for ${item.item_id}`);
     return;
@@ -80,11 +105,7 @@ function popupMenu(button: TrayButton, item: TrayItem): void {
   fetchMenuLayout(busName, objectPath)
     .then((root) => {
       if (!root) return;
-
-      // If the user clicked elsewhere while we were fetching, another popover
-      // may have opened. Close it first so we maintain the single-open
-      // invariant.
-      closeOpenPopover();
+      closeOpenTrayPopover();
 
       let popover: Gtk.Popover;
       try {
@@ -97,11 +118,26 @@ function popupMenu(button: TrayButton, item: TrayItem): void {
       popover.set_parent(button);
       popover.set_position(Gtk.PositionType.BOTTOM);
 
-      // Defer unparent to idle: `closed` is emitted from inside GTK's hide
-      // / grab-release path, so mutating the widget tree synchronously here
-      // can reenter under rapid open/close.
+      // ESC dismissal — replaces the keyboard escape that autohide:true
+      // would have given us for free.
+      const keyCtrl = new Gtk.EventControllerKey();
+      keyCtrl.connect("key-pressed", (_c, keyval) => {
+        if (keyval === Gdk.KEY_Escape) {
+          closeOpenTrayPopover();
+          return true;
+        }
+        return false;
+      });
+      popover.add_controller(keyCtrl);
+
+      // Defer unparent to idle: `closed` fires from inside GTK's hide path,
+      // so mutating the widget tree synchronously here can reenter under
+      // rapid open/close.
       popover.connect("closed", () => {
-        if (OPEN_POPOVER === popover) OPEN_POPOVER = null;
+        if (OPEN_POPOVER === popover) {
+          OPEN_POPOVER = null;
+          OPEN_OWNER = null;
+        }
         if (button._popover === popover) button._popover = null;
         GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
           try {
@@ -115,6 +151,7 @@ function popupMenu(button: TrayButton, item: TrayItem): void {
 
       button._popover = popover;
       OPEN_POPOVER = popover;
+      OPEN_OWNER = button;
       popover.popup();
     })
     .catch((err: unknown) => {
@@ -126,7 +163,6 @@ function popupMenu(button: TrayButton, item: TrayItem): void {
  * Tooltip resolution (markup-aware)
  * ------------------------------------------------------------------ */
 function resolveTooltipMarkup(item: AstalTray.TrayItem): string | null {
-  // 1️⃣ Explicit markup string
   if (
     typeof item.tooltip_markup === "string" &&
     item.tooltip_markup.length > 0
@@ -134,29 +170,24 @@ function resolveTooltipMarkup(item: AstalTray.TrayItem): string | null {
     return item.tooltip_markup;
   }
 
-  // 2️⃣ Boxed tooltip object (Discord, 1Password, etc.)
   const tooltipObj = item.tooltip as unknown;
   if (tooltipObj && typeof tooltipObj === "object") {
     const anyTooltip = tooltipObj as {
       text?: string;
       markup?: string;
     };
-
     if (typeof anyTooltip.markup === "string" && anyTooltip.markup.length > 0) {
       return anyTooltip.markup;
     }
-
     if (typeof anyTooltip.text === "string" && anyTooltip.text.length > 0) {
       return anyTooltip.text;
     }
   }
 
-  // 3️⃣ Title (udiskie, nm-applet)
   if (typeof item.title === "string" && item.title.length > 0) {
     return item.title;
   }
 
-  // 4️⃣ Fallback
   if (typeof item.id === "string" && item.id.length > 0) {
     return item.id;
   }
@@ -189,42 +220,46 @@ export function TrayItem(item: TrayItem): TrayButton {
 
   // PRIMARY CLICK
   button.connect("clicked", () => {
-    closeOpenPopover();
-
     try {
-      if (item.category !== AstalTray.Category.APPLICATION) {
-        popupMenu(button, item);
+      if (item.category === AstalTray.Category.APPLICATION) {
+        closeOpenTrayPopover();
+        item.activate(0, 0);
         return;
       }
 
-      item.activate(0, 0);
+      // Toggle: if our own popover is the one open, just close it.
+      if (button._popover && OPEN_POPOVER === button._popover) {
+        closeOpenTrayPopover();
+        return;
+      }
+
+      popupMenu(button, item);
     } catch (err) {
       log.error("activate failed:", err);
     }
   });
 
-  // SECONDARY CLICK: open menu
+  // SECONDARY CLICK: open menu (with same toggle semantics for non-app items)
   const rightClick = new Gtk.GestureClick();
   rightClick.set_button(Gdk.BUTTON_SECONDARY);
-
   rightClick.connect("released", () => {
-    closeOpenPopover();
+    if (button._popover && OPEN_POPOVER === button._popover) {
+      closeOpenTrayPopover();
+      return;
+    }
     popupMenu(button, item);
   });
-
   button.add_controller(rightClick);
 
-  // Cleanup for when SystemTray removes this widget. The popover is normally
-  // unparented on idle from its own `closed` handler; here we handle the
-  // edge case of the tray item being removed while its menu is still open.
+  // Cleanup for when SystemTray removes this widget.
   button._cleanup = () => {
     if (button._popover) {
-      if (OPEN_POPOVER === button._popover) closeOpenPopover();
+      if (OPEN_POPOVER === button._popover) closeOpenTrayPopover();
       button._popover = null;
     }
   };
 
-  // Use GObject property binding to avoid ref count issues with manual updates
+  // GObject property binding avoids ref count issues with manual gicon updates.
   item.bind_property("gicon", image, "gicon", GObject.BindingFlags.SYNC_CREATE);
 
   return button;

--- a/config/left/sys-tray/tray-item.tsx
+++ b/config/left/sys-tray/tray-item.tsx
@@ -174,19 +174,15 @@ export function TrayItem(item: TrayItem): TrayButton {
   }) as TrayButton;
 
   /* ----------------------------------------------------------------
-   * Tooltip attachment
-   *
-   * Resolved dynamically per-query: tray items mutate their tooltip
-   * (DBusMenu items, NetworkManager applet, etc.) after construction,
-   * and capturing the value once at attach time silently went stale.
-   * `attachTooltip` no-ops when the resolver returns null/empty, so it
-   * is safe to attach unconditionally even for items that currently
-   * expose no tooltip.
+   * Tooltip attachment (NEW)
    * ---------------------------------------------------------------- */
-  attachTooltip(button, {
-    text: () => resolveTooltipMarkup(item) ?? "",
-    classes: () => ["tray"],
-  });
+  const tooltip = resolveTooltipMarkup(item);
+  if (tooltip) {
+    attachTooltip(button, {
+      text: () => tooltip,
+      classes: () => ["tray"],
+    });
+  }
 
   // PRIMARY CLICK
   button.connect("clicked", () => {

--- a/config/left/sys-tray/tray-item.tsx
+++ b/config/left/sys-tray/tray-item.tsx
@@ -174,15 +174,19 @@ export function TrayItem(item: TrayItem): TrayButton {
   }) as TrayButton;
 
   /* ----------------------------------------------------------------
-   * Tooltip attachment (NEW)
+   * Tooltip attachment
+   *
+   * Resolved dynamically per-query: tray items mutate their tooltip
+   * (DBusMenu items, NetworkManager applet, etc.) after construction,
+   * and capturing the value once at attach time silently went stale.
+   * `attachTooltip` no-ops when the resolver returns null/empty, so it
+   * is safe to attach unconditionally even for items that currently
+   * expose no tooltip.
    * ---------------------------------------------------------------- */
-  const tooltip = resolveTooltipMarkup(item);
-  if (tooltip) {
-    attachTooltip(button, {
-      text: () => tooltip,
-      classes: () => ["tray"],
-    });
-  }
+  attachTooltip(button, {
+    text: () => resolveTooltipMarkup(item) ?? "",
+    classes: () => ["tray"],
+  });
 
   // PRIMARY CLICK
   button.connect("clicked", () => {

--- a/config/left/sys-tray/tray-item.tsx
+++ b/config/left/sys-tray/tray-item.tsx
@@ -3,6 +3,10 @@ import Gdk from "gi://Gdk?version=4.0";
 import GLib from "gi://GLib";
 import GObject from "gi://GObject";
 import Gtk from "gi://Gtk?version=4.0";
+import {
+  createManualBackdrop,
+  type TrayBackdropHandle,
+} from "helpers/backdrop";
 import { createLogger } from "helpers/logger";
 import { attachTooltip } from "helpers/tooltip";
 import { fetchMenuLayout } from "./dbusmenu";
@@ -33,6 +37,42 @@ type TrayButton = Gtk.Button & {
  * ------------------------------------------------------------------ */
 let OPEN_POPOVER: Gtk.Popover | null = null;
 let OPEN_OWNER: Gtk.Widget | null = null;
+let ACTIVE_BACKDROP: TrayBackdropHandle | null = null;
+
+/**
+ * Per-monitor backdrop registry. We scope backdrops to a single monitor
+ * (rather than spanning all outputs) to limit recovery blast-radius if
+ * the layer-shell overlay ever wedges input on that display — the user
+ * can still reach another monitor and `pkill gjs`.
+ */
+const BACKDROPS_BY_MONITOR = new Map<number, TrayBackdropHandle>();
+
+/** Resolve the monitor index (GListModel order) hosting `widget`. */
+function monitorIndexOfWidget(widget: Gtk.Widget): number | null {
+  const native = widget.get_native();
+  if (!native) return null;
+  const surface = native.get_surface();
+  if (!surface) return null;
+  const display = Gdk.Display.get_default();
+  if (!display) return null;
+  const monitor = display.get_monitor_at_surface(surface);
+  if (!monitor) return null;
+  const monitors = display.get_monitors();
+  for (let i = 0; i < monitors.get_n_items(); i++) {
+    if (monitors.get_item(i) === monitor) return i;
+  }
+  return null;
+}
+
+function backdropForMonitor(monitorIndex: number): TrayBackdropHandle {
+  const cached = BACKDROPS_BY_MONITOR.get(monitorIndex);
+  if (cached) return cached;
+  const handle = createManualBackdrop(monitorIndex, () => {
+    closeOpenTrayPopover();
+  });
+  BACKDROPS_BY_MONITOR.set(monitorIndex, handle);
+  return handle;
+}
 
 /** Close whatever tray popover is currently open. No-op if none. */
 export function closeOpenTrayPopover(): void {
@@ -44,6 +84,10 @@ export function closeOpenTrayPopover(): void {
   }
   OPEN_POPOVER = null;
   OPEN_OWNER = null;
+  if (ACTIVE_BACKDROP) {
+    ACTIVE_BACKDROP.hide();
+    ACTIVE_BACKDROP = null;
+  }
 }
 
 /** Whether `target` is a descendant of the currently-open tray popover. */
@@ -137,6 +181,10 @@ function popupMenu(button: TrayButton, item: TrayItem): void {
         if (OPEN_POPOVER === popover) {
           OPEN_POPOVER = null;
           OPEN_OWNER = null;
+          if (ACTIVE_BACKDROP) {
+            ACTIVE_BACKDROP.hide();
+            ACTIVE_BACKDROP = null;
+          }
         }
         if (button._popover === popover) button._popover = null;
         GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
@@ -152,6 +200,18 @@ function popupMenu(button: TrayButton, item: TrayItem): void {
       button._popover = popover;
       OPEN_POPOVER = popover;
       OPEN_OWNER = button;
+
+      // Show a click-catcher backdrop on the same monitor as the tray
+      // button. Without it (and without a Wayland popup grab — see
+      // autohide:false in menu.tsx), clicks on the desktop or other
+      // windows wouldn't dismiss the menu. Scoped per-monitor on purpose
+      // (see comment on createManualBackdrop in helpers/backdrop.tsx).
+      const monitorIndex = monitorIndexOfWidget(button);
+      if (monitorIndex !== null) {
+        ACTIVE_BACKDROP = backdropForMonitor(monitorIndex);
+        ACTIVE_BACKDROP.show();
+      }
+
       popover.popup();
     })
     .catch((err: unknown) => {

--- a/config/left/sys-tray/tray-item.tsx
+++ b/config/left/sys-tray/tray-item.tsx
@@ -1,10 +1,12 @@
 import AstalTray from "gi://AstalTray";
 import Gdk from "gi://Gdk?version=4.0";
-import Gio from "gi://Gio";
+import GLib from "gi://GLib";
 import GObject from "gi://GObject";
 import Gtk from "gi://Gtk?version=4.0";
 import { createLogger } from "helpers/logger";
 import { attachTooltip } from "helpers/tooltip";
+import { fetchMenuLayout } from "./dbusmenu";
+import { buildTrayMenu } from "./menu";
 
 const log = createLogger("Tray");
 
@@ -18,43 +20,6 @@ type TrayButton = Gtk.Button & {
 // ---- Global "only one popover open" state ----
 let OPEN_POPOVER: Gtk.Popover | null = null;
 
-/**
- * Walk a menu_model and collect the set of action prefixes referenced by
- * its items (e.g. `dbusmenu`, `app`, `unity`, `indicator`). The
- * StatusNotifierItem spec uses `dbusmenu.` exclusively, but in practice
- * different toolkits emit menus with different prefixes. We register the
- * action_group only under the prefixes that actually appear, plus
- * `dbusmenu` as a safety baseline (some bare menus rely on it implicitly).
- */
-function collectActionPrefixes(model: Gio.MenuModel): Set<string> {
-  const prefixes = new Set<string>(["dbusmenu"]);
-  const visit = (m: Gio.MenuModel): void => {
-    const n = m.get_n_items();
-    for (let i = 0; i < n; i++) {
-      const actionVar = m.get_item_attribute_value(
-        i,
-        Gio.MENU_ATTRIBUTE_ACTION,
-        null,
-      );
-      if (actionVar) {
-        const action = actionVar.get_string()[0];
-        const dot = action.indexOf(".");
-        if (dot > 0) prefixes.add(action.slice(0, dot));
-      }
-      const section = m.get_item_link(i, Gio.MENU_LINK_SECTION);
-      if (section) visit(section);
-      const submenu = m.get_item_link(i, Gio.MENU_LINK_SUBMENU);
-      if (submenu) visit(submenu);
-    }
-  };
-  try {
-    visit(model);
-  } catch (err) {
-    log.warn("menu prefix scan failed:", err);
-  }
-  return prefixes;
-}
-
 function closeOpenPopover(): void {
   if (!OPEN_POPOVER) return;
 
@@ -67,56 +32,94 @@ function closeOpenPopover(): void {
   OPEN_POPOVER = null;
 }
 
-function ensurePopover(button: TrayButton, item: TrayItem): Gtk.Popover | null {
-  if (!item.menu_model || !item.action_group) return null;
-
-  if (!button._popover) {
-    // Use PopoverMenu but access and manipulate its internal child
-    const popover = Gtk.PopoverMenu.new_from_model(item.menu_model);
-    popover.set_parent(button);
-    popover.set_has_arrow(false);
-    popover.set_autohide(true);
-    // Drop the menu downward from the bar, matching every other GTK status
-    // tray. The previous PositionType.LEFT meant the popover was anchored
-    // to the *left* of the button — which on a top bar with the tray on
-    // the left of the screen pushes the menu off-screen and gets clipped
-    // by the monitor edge. BOTTOM is the natural reading direction and
-    // GTK auto-flips horizontally if the menu would overflow the right
-    // edge, so it works for tray icons placed anywhere along the bar.
-    popover.set_position(Gtk.PositionType.BOTTOM);
-    popover.add_css_class("tray-menu");
-
-    // Register the action_group only under prefixes the menu actually
-    // uses. Previously we blanket-registered under dbusmenu/app/unity/
-    // indicator which works but pollutes GTK's action map per item and
-    // makes activation lookups ambiguous. See AUDIT C-1.10.
-    if (item.action_group) {
-      const prefixes = collectActionPrefixes(item.menu_model);
-      for (const p of prefixes) {
-        popover.insert_action_group(p, item.action_group);
-      }
-    }
-
-    popover.connect("closed", () => {
-      if (OPEN_POPOVER === popover) OPEN_POPOVER = null;
-    });
-
-    button._popover = popover;
-  }
-
-  return button._popover;
+/**
+ * Recover the tray app's well-known D-Bus name from `item.item_id`.
+ *
+ * AstalTray composes `item_id = service + object_path` where `object_path`
+ * starts with `/` (e.g. `org.kde.StatusNotifierItem-1234-1/StatusNotifierItem`).
+ * Splitting on the first `/` gives us the bus name.
+ *
+ * We can't use the well-known-vs-unique-name distinction from AstalTray
+ * (which uses `proxy.g_name_owner`, the unique `:1.NN` name) — that's not
+ * exposed in the gir. The well-known name is fine: D-Bus routes to the
+ * current owner automatically.
+ */
+function busNameFromItemId(itemId: string): string | null {
+  const slash = itemId.indexOf("/");
+  if (slash <= 0) return null;
+  return itemId.substring(0, slash);
 }
 
-function popupMenu(button: TrayButton, item: TrayItem): void {
-  const popover = ensurePopover(button, item);
-  if (!popover) return;
+/** Read the unintrospectable `menu_path` property at runtime. */
+function menuObjectPath(item: TrayItem): string | null {
+  // `menu_path` is typed `never` in the gir because it's `ObjectPath`, but
+  // at runtime it's a plain string (or null). Cast through `unknown`.
+  const raw = (item as unknown as { menu_path?: string | null }).menu_path;
+  return typeof raw === "string" && raw.startsWith("/") ? raw : null;
+}
 
-  if (OPEN_POPOVER && OPEN_POPOVER !== popover) {
-    closeOpenPopover();
+/**
+ * Open the tray menu for `item`. Fetches layout over D-Bus, builds the
+ * popover, and pops it up.
+ *
+ * Fetching is async (~ms over the session bus), so the popover appears
+ * slightly after the click. We intentionally don't pre-fetch: the freshest
+ * layout is the one the user expects.
+ */
+function popupMenu(button: TrayButton, item: TrayItem): void {
+  closeOpenPopover();
+
+  const busName = busNameFromItemId(item.item_id);
+  const objectPath = menuObjectPath(item);
+
+  if (!busName || !objectPath) {
+    log.debug(`no dbusmenu coordinates for ${item.item_id}`);
+    return;
   }
 
-  OPEN_POPOVER = popover;
-  popover.popup();
+  fetchMenuLayout(busName, objectPath)
+    .then((root) => {
+      if (!root) return;
+
+      // If the user clicked elsewhere while we were fetching, another popover
+      // may have opened. Close it first so we maintain the single-open
+      // invariant.
+      closeOpenPopover();
+
+      let popover: Gtk.Popover;
+      try {
+        popover = buildTrayMenu(root, busName, objectPath);
+      } catch (err) {
+        log.warn("menu construction failed:", err);
+        return;
+      }
+
+      popover.set_parent(button);
+      popover.set_position(Gtk.PositionType.BOTTOM);
+
+      // Defer unparent to idle: `closed` is emitted from inside GTK's hide
+      // / grab-release path, so mutating the widget tree synchronously here
+      // can reenter under rapid open/close.
+      popover.connect("closed", () => {
+        if (OPEN_POPOVER === popover) OPEN_POPOVER = null;
+        if (button._popover === popover) button._popover = null;
+        GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+          try {
+            popover.unparent();
+          } catch {
+            /* ignore */
+          }
+          return GLib.SOURCE_REMOVE;
+        });
+      });
+
+      button._popover = popover;
+      OPEN_POPOVER = popover;
+      popover.popup();
+    })
+    .catch((err: unknown) => {
+      log.warn(`fetchMenuLayout for ${item.item_id} threw:`, err);
+    });
 }
 
 /* ------------------------------------------------------------------
@@ -174,7 +177,7 @@ export function TrayItem(item: TrayItem): TrayButton {
   }) as TrayButton;
 
   /* ----------------------------------------------------------------
-   * Tooltip attachment (NEW)
+   * Tooltip attachment
    * ---------------------------------------------------------------- */
   const tooltip = resolveTooltipMarkup(item);
   if (tooltip) {
@@ -211,18 +214,12 @@ export function TrayItem(item: TrayItem): TrayButton {
 
   button.add_controller(rightClick);
 
-  // Cleanup for when SystemTray removes this widget
+  // Cleanup for when SystemTray removes this widget. The popover is normally
+  // unparented on idle from its own `closed` handler; here we handle the
+  // edge case of the tray item being removed while its menu is still open.
   button._cleanup = () => {
-    if (button._popover && OPEN_POPOVER === button._popover) {
-      closeOpenPopover();
-    }
-
     if (button._popover) {
-      try {
-        button._popover.unparent();
-      } catch {
-        /* ignore */
-      }
+      if (OPEN_POPOVER === button._popover) closeOpenPopover();
       button._popover = null;
     }
   };

--- a/config/left/sys-tray/tray-item.tsx
+++ b/config/left/sys-tray/tray-item.tsx
@@ -35,7 +35,14 @@ function ensurePopover(button: TrayButton, item: TrayItem): Gtk.Popover | null {
     popover.set_parent(button);
     popover.set_has_arrow(false);
     popover.set_autohide(true);
-    popover.set_position(Gtk.PositionType.LEFT);
+    // Drop the menu downward from the bar, matching every other GTK status
+    // tray. The previous PositionType.LEFT meant the popover was anchored
+    // to the *left* of the button — which on a top bar with the tray on
+    // the left of the screen pushes the menu off-screen and gets clipped
+    // by the monitor edge. BOTTOM is the natural reading direction and
+    // GTK auto-flips horizontally if the menu would overflow the right
+    // edge, so it works for tray icons placed anywhere along the bar.
+    popover.set_position(Gtk.PositionType.BOTTOM);
     popover.add_css_class("tray-menu");
 
     // Register action group with multiple prefixes to support different tray items

--- a/config/left/sys-tray/tray-item.tsx
+++ b/config/left/sys-tray/tray-item.tsx
@@ -3,7 +3,10 @@ import Gdk from "gi://Gdk?version=4.0";
 import Gio from "gi://Gio";
 import GObject from "gi://GObject";
 import Gtk from "gi://Gtk?version=4.0";
+import { createLogger } from "helpers/logger";
 import { attachTooltip } from "helpers/tooltip";
+
+const log = createLogger("Tray");
 
 type TrayItem = AstalTray.TrayItem;
 
@@ -47,7 +50,7 @@ function collectActionPrefixes(model: Gio.MenuModel): Set<string> {
   try {
     visit(model);
   } catch (err) {
-    console.warn("Tray menu prefix scan failed:", err);
+    log.warn("menu prefix scan failed:", err);
   }
   return prefixes;
 }
@@ -193,7 +196,7 @@ export function TrayItem(item: TrayItem): TrayButton {
 
       item.activate(0, 0);
     } catch (err) {
-      console.error("Tray activate failed:", err);
+      log.error("activate failed:", err);
     }
   });
 

--- a/config/left/sys-tray/tray-item.tsx
+++ b/config/left/sys-tray/tray-item.tsx
@@ -270,12 +270,83 @@ export function TrayItem(item: TrayItem): TrayButton {
 
   /* ----------------------------------------------------------------
    * Tooltip attachment
+   *
+   * Tooltip text on a SNI can be empty at construction (apps publish it
+   * after their main window is fully realised) or change over the
+   * item's lifetime (e.g. NetworkManager rewriting connection state).
+   *
+   * Strategy:
+   *   - If a tooltip is already present, attach immediately with a
+   *     resolver that re-reads the current value on every hover. The
+   *     `if (tooltip)` gate stays — we never add a motion controller to
+   *     a button that has no tooltip to show, because the controller has
+   *     subtle interactions with the GtkPopoverMenu we attach on click
+   *     (cf. AUDIT.md C-2.9, regression `66eb700` → `0987dc7`).
+   *   - If a tooltip is initially absent, listen for the first time the
+   *     SNI publishes one and attach then. Two properties may fire:
+   *     `tooltip-markup` (Astal-cooked, what resolveTooltipMarkup reads
+   *     first) and the unintrospectable `tooltip` struct. We watch both
+   *     and self-disarm once a tooltip resolves.
    * ---------------------------------------------------------------- */
-  const tooltip = resolveTooltipMarkup(item);
-  if (tooltip) {
+  const dynamicText = (): string => resolveTooltipMarkup(item) ?? "";
+
+  if (resolveTooltipMarkup(item)) {
     attachTooltip(button, {
-      text: () => tooltip,
+      text: dynamicText,
       classes: () => ["tray"],
+      updateInterval: 1000,
+    });
+  } else {
+    let attached = false;
+    let markupHandler: number | null = null;
+    let structHandler: number | null = null;
+
+    const tryAttach = (): void => {
+      if (attached) return;
+      if (resolveTooltipMarkup(item) === null) return;
+      attached = true;
+      attachTooltip(button, {
+        text: dynamicText,
+        classes: () => ["tray"],
+        updateInterval: 1000,
+      });
+      if (markupHandler !== null) item.disconnect(markupHandler);
+      if (structHandler !== null) item.disconnect(structHandler);
+      markupHandler = null;
+      structHandler = null;
+    };
+
+    try {
+      markupHandler = item.connect("notify::tooltip-markup", tryAttach);
+    } catch {
+      // Some SNI implementations don't expose the property; ignore.
+    }
+    try {
+      structHandler = item.connect("notify::tooltip", tryAttach);
+    } catch {
+      // ditto
+    }
+
+    // If the button is destroyed before a tooltip ever appears, drop the
+    // watchers so we don't leak signal handlers on the long-lived
+    // TrayItem.
+    registerCleanup(button, () => {
+      if (markupHandler !== null) {
+        try {
+          item.disconnect(markupHandler);
+        } catch {
+          // already disconnected by tryAttach
+        }
+        markupHandler = null;
+      }
+      if (structHandler !== null) {
+        try {
+          item.disconnect(structHandler);
+        } catch {
+          // already disconnected by tryAttach
+        }
+        structHandler = null;
+      }
     });
   }
 

--- a/config/left/sys-tray/tray-item.tsx
+++ b/config/left/sys-tray/tray-item.tsx
@@ -7,6 +7,7 @@ import {
   createManualBackdrop,
   type TrayBackdropHandle,
 } from "helpers/backdrop";
+import { registerCleanup } from "helpers/cleanup";
 import { createLogger } from "helpers/logger";
 import { attachTooltip } from "helpers/tooltip";
 import { fetchMenuLayout } from "./dbusmenu";
@@ -312,12 +313,12 @@ export function TrayItem(item: TrayItem): TrayButton {
   button.add_controller(rightClick);
 
   // Cleanup for when SystemTray removes this widget.
-  button._cleanup = () => {
+  registerCleanup(button, () => {
     if (button._popover) {
       if (OPEN_POPOVER === button._popover) closeOpenTrayPopover();
       button._popover = null;
     }
-  };
+  });
 
   // GObject property binding avoids ref count issues with manual gicon updates.
   item.bind_property("gicon", image, "gicon", GObject.BindingFlags.SYNC_CREATE);

--- a/config/notifications/popup-state.ts
+++ b/config/notifications/popup-state.ts
@@ -1,0 +1,189 @@
+import GLib from "gi://GLib";
+import type Gtk from "gi://Gtk?version=4.0";
+import {
+  type NotificationData,
+  notificationService,
+} from "services/notifications";
+
+/* -----------------------------
+ * Global popup state model
+ *
+ * Single source of truth for live popup notifications. Per-monitor
+ * `PopupNotificationContainer`s become thin views that subscribe here and
+ * (un)parent rows depending on whether their monitor is currently focused.
+ *
+ * Why this exists:
+ *   - Synchronous-tag replacement (e.g. volume / brightness OSDs) has to be
+ *     a global operation. Previously the dedupe map lived inside each
+ *     per-monitor container, so a new OSD on the focused monitor wouldn't
+ *     replace a stale OSD still ticking on a previously-focused monitor.
+ *   - Reparenting an existing row across monitors avoids the visual
+ *     "rebuild flash" of tearing down and re-creating identical widgets.
+ *   - One shared 10 Hz timer drives every popup's progress bar, instead of
+ *     per-popup 50 ms timers. Self-cancels when the popup set empties.
+ * ----------------------------- */
+
+const POPUP_TIMEOUT_MS = 10000;
+const PROGRESS_TICK_MS = 100;
+
+export interface LivePopup {
+  id: number;
+  notification: NotificationData;
+  /** Outer row widget. Reparented across monitor views; never destroyed
+   *  until the popup expires or is dismissed. */
+  widget: Gtk.Widget;
+  /** Progress bar inside the row. Driven by the shared timer. */
+  progress: Gtk.ProgressBar;
+  /** Monotonic time (µs) when the popup first appeared. */
+  startTime: number;
+  /** `${appName}\x00${syncTag}` if this notification is sync-tagged, else
+   *  null. Used by addPopupGlobal() to dedupe replacements. */
+  syncKey: string | null;
+  /** Per-popup cleanup hook installed by the row builder. */
+  cleanup?: () => void;
+}
+
+const livePopups = new Map<number, LivePopup>();
+const syncTagToId = new Map<string, number>();
+const listeners = new Set<() => void>();
+let sharedTimerId: number | null = null;
+
+function syncKey(appName: string, tag: string): string {
+  return `${appName}\x00${tag}`;
+}
+
+function notifyListeners(): void {
+  for (const fn of listeners) {
+    try {
+      fn();
+    } catch (_e) {
+      // listeners must not throw; swallow defensively.
+    }
+  }
+}
+
+function ensureSharedTimer(): void {
+  if (sharedTimerId !== null) return;
+  sharedTimerId = GLib.timeout_add(
+    GLib.PRIORITY_DEFAULT,
+    PROGRESS_TICK_MS,
+    () => {
+      const now = GLib.get_monotonic_time();
+      // Iterate over a snapshot — expiry mutates livePopups.
+      const snapshot = Array.from(livePopups.values());
+      for (const p of snapshot) {
+        const elapsed = (now - p.startTime) / 1000; // µs → ms
+        const remaining = Math.max(0, POPUP_TIMEOUT_MS - elapsed);
+        p.progress.fraction = remaining / POPUP_TIMEOUT_MS;
+        if (remaining <= 0) {
+          // Treat timeout as a normal removal. The notification service has
+          // already excluded transient / sync-tagged popups from history, so
+          // we just drop the widget.
+          removePopupGlobal(p.id);
+        }
+      }
+      if (livePopups.size === 0) {
+        sharedTimerId = null;
+        return GLib.SOURCE_REMOVE;
+      }
+      return GLib.SOURCE_CONTINUE;
+    },
+  );
+}
+
+/**
+ * Get a stable, ordered list of live popups. Order matches insertion order
+ * (oldest first); callers may reverse if they want newest-on-top.
+ */
+export function getLivePopups(): LivePopup[] {
+  return Array.from(livePopups.values());
+}
+
+/** Subscribe to live-popup-set changes. Returns an unsubscribe callback. */
+export function subscribePopups(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+/**
+ * Register a new popup. The caller has already built the row widget
+ * (presentation only — no signal subscriptions or timers) and passes it in.
+ * If the notification carries a sync tag, any prior popup with the same
+ * `(appName, syncTag)` is removed first and its server-side notification
+ * dismissed (mirroring what the user pressing "close" does).
+ */
+export function addPopupGlobal(args: {
+  notification: NotificationData;
+  widget: Gtk.Widget;
+  progress: Gtk.ProgressBar;
+  cleanup?: () => void;
+}): void {
+  const { notification, widget, progress, cleanup } = args;
+
+  if (livePopups.has(notification.id)) return;
+
+  let key: string | null = null;
+  if (notification.syncTag !== null) {
+    key = syncKey(notification.appName, notification.syncTag);
+    const priorId = syncTagToId.get(key);
+    if (priorId !== undefined && priorId !== notification.id) {
+      notificationService.dismissDuringPopup(priorId);
+      removePopupGlobal(priorId);
+    }
+    syncTagToId.set(key, notification.id);
+  }
+
+  const entry: LivePopup = {
+    id: notification.id,
+    notification,
+    widget,
+    progress,
+    startTime: GLib.get_monotonic_time(),
+    syncKey: key,
+    cleanup,
+  };
+  livePopups.set(notification.id, entry);
+  ensureSharedTimer();
+  notifyListeners();
+}
+
+/**
+ * Remove a popup by id. Runs the row's cleanup hook, unparents the widget
+ * from whichever view currently holds it, and clears any sync-tag mapping.
+ */
+export function removePopupGlobal(id: number): void {
+  const entry = livePopups.get(id);
+  if (!entry) return;
+
+  entry.cleanup?.();
+
+  // Unparent from whichever container currently holds it. Views are
+  // responsible for re-querying via subscribePopups and removing/adding
+  // children to match, but unparenting here defensively avoids leaking the
+  // widget if no view picks up the change in time.
+  const parent = entry.widget.get_parent();
+  if (parent) {
+    try {
+      (parent as unknown as { remove?: (w: Gtk.Widget) => void }).remove?.(
+        entry.widget,
+      );
+    } catch (_e) {
+      // Some containers don't expose remove(); fall back to unparent.
+      entry.widget.unparent();
+    }
+  }
+
+  livePopups.delete(id);
+  if (entry.syncKey !== null && syncTagToId.get(entry.syncKey) === id) {
+    syncTagToId.delete(entry.syncKey);
+  }
+  notifyListeners();
+}
+
+/** Whether any live popups exist. Cheap; useful for empty/hasNotifications
+ *  bookkeeping in views. */
+export function livePopupCount(): number {
+  return livePopups.size;
+}

--- a/config/notifications/popup-state.ts
+++ b/config/notifications/popup-state.ts
@@ -1,5 +1,5 @@
 import GLib from "gi://GLib";
-import type Gtk from "gi://Gtk?version=4.0";
+import Gtk from "gi://Gtk?version=4.0";
 import {
   type NotificationData,
   notificationService,
@@ -166,12 +166,15 @@ export function removePopupGlobal(id: number): void {
   const parent = entry.widget.get_parent();
   if (parent) {
     try {
-      (parent as unknown as { remove?: (w: Gtk.Widget) => void }).remove?.(
-        entry.widget,
-      );
-    } catch (_e) {
-      // Some containers don't expose remove(); fall back to unparent.
-      entry.widget.unparent();
+      if (parent instanceof Gtk.Box) {
+        parent.remove(entry.widget);
+      } else {
+        // Defensive: unparent regardless of container kind. Falls back to
+        // unparent() which works for any Widget child.
+        entry.widget.unparent();
+      }
+    } catch {
+      // Best-effort; if reparenting already happened we may get here.
     }
   }
 

--- a/config/notifications/popup-window.tsx
+++ b/config/notifications/popup-window.tsx
@@ -1,9 +1,35 @@
+import Gdk from "gi://Gdk?version=4.0";
 import type Gtk from "gi://Gtk?version=4.0";
 import { Astal } from "ags/gtk4";
 import { PopupNotificationContainer } from "./popup";
 
+/**
+ * Resolve a monitor's connector name directly by its index in the Gdk
+ * monitor list. This is the same index we pass to `<window monitor={i}>` so
+ * the mapping is exact — unlike `get_monitor_at_surface(surface)` which is
+ * unreliable for layer-shell windows (it can return the monitor under the
+ * pointer instead of the one the surface is anchored to, leading to popups
+ * showing on the wrong monitor when the cursor is elsewhere).
+ */
+function connectorForMonitorIndex(index: number): string | null {
+  try {
+    const display = Gdk.Display.get_default();
+    if (!display) return null;
+    const monitors = display.get_monitors();
+    const monitor = monitors.get_item(index) as Gdk.Monitor | null;
+    return monitor?.get_connector?.() ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export function PopupNotificationWindow(monitorIndex: number): Gtk.Window {
   const { TOP, RIGHT } = Astal.WindowAnchor;
+
+  // Resolve once at construction — the monitor index is fixed for the
+  // lifetime of this window, and the Gdk monitor list is already populated
+  // by the time we're called (otherwise we wouldn't have an index).
+  const ownConnector = connectorForMonitorIndex(monitorIndex);
 
   const win = (
     <window
@@ -19,6 +45,7 @@ export function PopupNotificationWindow(monitorIndex: number): Gtk.Window {
       margin_right={8}
     >
       <PopupNotificationContainer
+        getMonitorConnector={() => ownConnector}
         onEmpty={() => {
           win.visible = false;
           win.set_default_size(0, -1);

--- a/config/notifications/popup-window.tsx
+++ b/config/notifications/popup-window.tsx
@@ -1,6 +1,7 @@
 import Gdk from "gi://Gdk?version=4.0";
 import type Gtk from "gi://Gtk?version=4.0";
 import { Astal } from "ags/gtk4";
+import { asWindow } from "helpers/jsx";
 import { PopupNotificationContainer } from "./popup";
 
 /**
@@ -31,7 +32,7 @@ export function PopupNotificationWindow(monitorIndex: number): Gtk.Window {
   // by the time we're called (otherwise we wouldn't have an index).
   const ownConnector = connectorForMonitorIndex(monitorIndex);
 
-  const win = (
+  const win = asWindow(
     <window
       name={`notification-popup-${monitorIndex}`}
       visible={false}
@@ -55,8 +56,8 @@ export function PopupNotificationWindow(monitorIndex: number): Gtk.Window {
           win.set_default_size(-1, -1);
         }}
       />
-    </window>
-  ) as unknown as Gtk.Window;
+    </window>,
+  );
 
   return win;
 }

--- a/config/notifications/popup.tsx
+++ b/config/notifications/popup.tsx
@@ -1,5 +1,6 @@
 import Gtk from "gi://Gtk?version=4.0";
 import { getCompositor } from "compositors";
+import { registerCleanup } from "helpers/cleanup";
 import { resolveNotificationIcon } from "helpers/icon-resolver";
 import {
   type NotificationData,
@@ -321,14 +322,14 @@ export function PopupNotificationContainer(
   refresh();
 
   // Cleanup
-  (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  registerCleanup(container, () => {
     unsubPopups();
     unsubCompositor();
     unsubService?.();
     unsubServiceMain?.();
     unregisterDriverCandidate();
     detachAll();
-  };
+  });
 
   return container;
 }

--- a/config/notifications/popup.tsx
+++ b/config/notifications/popup.tsx
@@ -226,9 +226,11 @@ export function PopupNotificationContainer(
       if (currentParent === container) continue;
       if (currentParent) {
         try {
-          (
-            currentParent as unknown as { remove?: (w: Gtk.Widget) => void }
-          ).remove?.(p.widget);
+          if (currentParent instanceof Gtk.Box) {
+            currentParent.remove(p.widget);
+          } else {
+            p.widget.unparent();
+          }
         } catch (_e) {
           p.widget.unparent();
         }

--- a/config/notifications/popup.tsx
+++ b/config/notifications/popup.tsx
@@ -1,4 +1,3 @@
-import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 import { getCompositor } from "compositors";
 import { resolveNotificationIcon } from "helpers/icon-resolver";
@@ -6,74 +5,31 @@ import {
   type NotificationData,
   notificationService,
 } from "services/notifications";
-
-const POPUP_TIMEOUT = 10000; // 10 seconds
-const PROGRESS_TICK_MS = 100; // shared scheduler cadence
+import {
+  addPopupGlobal,
+  getLivePopups,
+  livePopupCount,
+  removePopupGlobal,
+  subscribePopups,
+} from "./popup-state";
 
 /* -----------------------------
- * Shared progress scheduler
+ * Presentation: a single popup row
  *
- * One GLib source ticks every PROGRESS_TICK_MS and drives every live popup's
- * progress bar. Previously each PopupNotification spawned its own 50ms timer,
- * meaning N monitors × M popups × 20Hz wakeups. Now: a single 10Hz source for
- * the whole app, regardless of popup count.
+ * Pure presentation — no signal subscriptions, no timers, no per-row state
+ * beyond what's needed to update the progress bar. The row is owned by
+ * popup-state's livePopups map and reparented across per-monitor views.
  * ----------------------------- */
 
-interface SharedPopupEntry {
-  startTime: number; // GLib.get_monotonic_time() in microseconds
+interface PopupNotificationRowResult {
+  widget: Gtk.Box;
   progress: Gtk.ProgressBar;
-  onTimeout: () => void;
+  cleanup: () => void;
 }
 
-const sharedPopups = new Set<SharedPopupEntry>();
-let sharedTimerId: number | null = null;
-
-function ensureSharedTimer(): void {
-  if (sharedTimerId !== null) return;
-  sharedTimerId = GLib.timeout_add(
-    GLib.PRIORITY_DEFAULT,
-    PROGRESS_TICK_MS,
-    () => {
-      // Iterate over a snapshot so onTimeout handlers can mutate the set.
-      const snapshot = Array.from(sharedPopups);
-      const now = GLib.get_monotonic_time();
-      for (const entry of snapshot) {
-        const elapsed = (now - entry.startTime) / 1000; // µs → ms
-        const remaining = Math.max(0, POPUP_TIMEOUT - elapsed);
-        entry.progress.fraction = remaining / POPUP_TIMEOUT;
-        if (remaining <= 0) {
-          sharedPopups.delete(entry);
-          entry.onTimeout();
-        }
-      }
-      if (sharedPopups.size === 0) {
-        sharedTimerId = null;
-        return GLib.SOURCE_REMOVE;
-      }
-      return GLib.SOURCE_CONTINUE;
-    },
-  );
-}
-
-function registerPopupProgress(entry: SharedPopupEntry): void {
-  sharedPopups.add(entry);
-  ensureSharedTimer();
-}
-
-function unregisterPopupProgress(entry: SharedPopupEntry): void {
-  sharedPopups.delete(entry);
-  // Timer is self-cancelling once the set empties; no need to remove here.
-}
-
-interface PopupNotificationProps {
-  notification: NotificationData;
-  onDismiss: () => void;
-  onTimeout: () => void;
-}
-
-function PopupNotification(props: PopupNotificationProps): Gtk.Box {
-  const { notification, onDismiss, onTimeout } = props;
-
+function PopupNotificationRow(
+  notification: NotificationData,
+): PopupNotificationRowResult {
   const container = new Gtk.Box({
     orientation: Gtk.Orientation.VERTICAL,
     spacing: 0,
@@ -95,26 +51,23 @@ function PopupNotification(props: PopupNotificationProps): Gtk.Box {
     css_classes: ["popup-header"],
   });
 
-  // Notification icon - prioritize custom image, then app icon, fallback to bell
+  // Notification icon — prioritize custom image, then app icon, fallback bell.
   const notifIcon = resolveNotificationIcon(
     notification.image,
     notification.appIcon,
     notification.appName,
   );
   let iconWidget: Gtk.Widget;
-
   if (notifIcon) {
     const iconImage = Gtk.Image.new_from_gicon(notifIcon);
     iconImage.set_pixel_size(24);
     iconImage.set_css_classes(["popup-icon"]);
     iconWidget = iconImage;
   } else {
-    // Fallback to bell icon
-    const iconLabel = new Gtk.Label({
+    iconWidget = new Gtk.Label({
       label: "󰂚",
       css_classes: ["popup-icon"],
     });
-    iconWidget = iconLabel;
   }
   header.append(iconWidget);
 
@@ -134,9 +87,9 @@ function PopupNotification(props: PopupNotificationProps): Gtk.Box {
     css_classes: ["popup-close"],
     valign: Gtk.Align.START,
   });
-  closeBtn.connect("clicked", () => {
+  const closeHandler = closeBtn.connect("clicked", () => {
     notificationService.dismissDuringPopup(notification.id);
-    onDismiss();
+    removePopupGlobal(notification.id);
   });
   header.append(closeBtn);
 
@@ -173,38 +126,40 @@ function PopupNotification(props: PopupNotificationProps): Gtk.Box {
     body.append(bodyLabel);
   }
 
-  // Progress bar for timeout (inside body)
+  // Progress bar — fraction is updated by the shared timer in popup-state.
   const progress = new Gtk.ProgressBar({
     css_classes: ["popup-progress"],
     fraction: 1.0,
   });
   body.append(progress);
-
   container.append(body);
 
-  // Timeout animation — driven by the shared scheduler.
-  const entry: SharedPopupEntry = {
-    startTime: GLib.get_monotonic_time(),
-    progress,
-    onTimeout,
-  };
-  registerPopupProgress(entry);
-
-  // Cleanup
-  (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
-    unregisterPopupProgress(entry);
+  const cleanup = (): void => {
+    try {
+      closeBtn.disconnect(closeHandler);
+    } catch (_e) {
+      // Button may already be unrealised; ignore.
+    }
   };
 
-  return container;
+  return { widget: container, progress, cleanup };
 }
+
+/* -----------------------------
+ * Per-monitor view
+ *
+ * Subscribes to (a) the compositor's focused-monitor (via the existing
+ * onFocusedWorkspaceChanged event which fires on focus-follows-mouse in
+ * Hyprland and on workspace changes in niri) and (b) the global popup
+ * state. When this monitor is focused, it (re)parents every live row into
+ * itself; when it loses focus, it detaches them and the next-focused
+ * monitor's view picks them up.
+ * ----------------------------- */
 
 interface PopupNotificationContainerProps {
   /**
    * Connector name of the monitor this container lives on (e.g. "DP-2").
-   * Used to gate popup creation to the focused monitor only.
-   * Resolved lazily by the caller — typically via `getMonitorConnectorName`
-   * once the parent window is realised. If null, the container accepts
-   * popups unconditionally (fallback: no focused-monitor info available).
+   * Used to decide whether this view should display popups.
    */
   getMonitorConnector?: () => string | null;
   onEmpty?: () => void;
@@ -215,119 +170,208 @@ export function PopupNotificationContainer(
   props?: PopupNotificationContainerProps,
 ): Gtk.Box {
   const compositor = getCompositor();
+
   const container = new Gtk.Box({
     orientation: Gtk.Orientation.VERTICAL,
     spacing: 8,
     css_classes: ["popup-notification-container"],
   });
 
-  const popups = new Map<number, Gtk.Widget>();
-  // Track currently-shown popup id per (appName + syncTag) so a follow-up
-  // notification with the same tag replaces the existing popup instead of
-  // stacking. This is what makes volume / brightness OSDs feel right.
-  const syncTagToId = new Map<string, number>();
+  let isFocused = false;
+  let lastEmpty = true;
 
-  function syncKey(appName: string, tag: string): string {
-    return `${appName}\x00${tag}`;
-  }
+  const ownConnector = (): string | null =>
+    props?.getMonitorConnector?.() ?? null;
 
-  function checkAndNotify(): void {
-    if (popups.size === 0) {
+  const isOwnerOfFocus = (): boolean => {
+    const own = ownConnector();
+    const focused = compositor.getFocusedMonitor();
+    // If either side is unknown, fall through: best-effort show.
+    // This covers the fallback compositor and pre-bootstrap startup.
+    if (own === null || focused === null) return true;
+    return own === focused;
+  };
+
+  // Detach every row currently parented into this container (without
+  // destroying the widget — popup-state still owns it).
+  const detachAll = (): void => {
+    let child = container.get_first_child();
+    while (child) {
+      const next = child.get_next_sibling();
+      container.remove(child);
+      child = next;
+    }
+  };
+
+  // (Re)parent live rows from popup-state into this container, in the
+  // order popup-state reports them. If a row is currently parented in
+  // another monitor's view, unparent it first.
+  const attachAll = (): void => {
+    const popups = getLivePopups();
+    // First: remove any child we hold that isn't in the live set anymore.
+    const liveIds = new Set(popups.map((p) => p.id));
+    let child = container.get_first_child();
+    while (child) {
+      const next = child.get_next_sibling();
+      const id = (child as Gtk.Widget & { _popupId?: number })._popupId;
+      if (id === undefined || !liveIds.has(id)) {
+        container.remove(child);
+      }
+      child = next;
+    }
+    // Then: append any live popup not already in this container, in order.
+    for (const p of popups) {
+      const currentParent = p.widget.get_parent();
+      if (currentParent === container) continue;
+      if (currentParent) {
+        try {
+          (
+            currentParent as unknown as { remove?: (w: Gtk.Widget) => void }
+          ).remove?.(p.widget);
+        } catch (_e) {
+          p.widget.unparent();
+        }
+      }
+      (p.widget as Gtk.Widget & { _popupId?: number })._popupId = p.id;
+      container.append(p.widget);
+    }
+  };
+
+  const checkAndNotify = (): void => {
+    const empty = livePopupCount() === 0 || !isFocused;
+    if (empty && !lastEmpty) {
+      lastEmpty = true;
       props?.onEmpty?.();
-    } else if (popups.size === 1) {
-      // Just got first notification
+    } else if (!empty && lastEmpty) {
+      lastEmpty = false;
       props?.onHasNotifications?.();
     }
-  }
+  };
 
-  function addPopup(notification: NotificationData): void {
-    // Don't show duplicate popups
-    if (popups.has(notification.id)) return;
-
-    // Focused-monitor gating: only the currently-focused monitor renders
-    // popups. Resolved at popup-arrival time; we don't migrate popups across
-    // monitors mid-lifetime. If we can't resolve our own connector or the
-    // compositor can't tell us the focused monitor, fall through and show
-    // the popup (best-effort fallback).
-    const ownConnector = props?.getMonitorConnector?.() ?? null;
-    const focused = compositor.getFocusedMonitor();
-    if (ownConnector !== null && focused !== null && ownConnector !== focused) {
-      return;
-    }
-
-    // Synchronous-tag replacement: dismiss any prior popup that shares the
-    // same (appName, syncTag) key before showing the new one.
-    if (notification.syncTag !== null) {
-      const key = syncKey(notification.appName, notification.syncTag);
-      const priorId = syncTagToId.get(key);
-      if (priorId !== undefined && priorId !== notification.id) {
-        // Mirror what the user pressing "close" does — remove from the
-        // server too so the prior notification doesn't linger as resolved
-        // history elsewhere.
-        notificationService.dismissDuringPopup(priorId);
-        removePopup(priorId);
+  const refresh = (): void => {
+    const shouldBeFocused = isOwnerOfFocus();
+    if (shouldBeFocused !== isFocused) {
+      isFocused = shouldBeFocused;
+      if (!isFocused) {
+        detachAll();
       }
-      syncTagToId.set(key, notification.id);
     }
+    if (isFocused) {
+      attachAll();
+    }
+    checkAndNotify();
+  };
 
-    const popup = PopupNotification({
-      notification,
-      onDismiss: () => {
-        removePopup(notification.id);
-      },
-      onTimeout: () => {
-        // Timeout means it should go to history (unless transient/sync-tagged
-        // — the service has already excluded those from getNotifications()).
-        removePopup(notification.id);
-      },
+  // Subscribe to the global popup set.
+  const unsubPopups = subscribePopups(refresh);
+
+  // Subscribe to focus changes. Hyprland's notify::focused-workspace fires
+  // on focus-follows-mouse cross; niri's WorkspaceActivated fires on
+  // keyboard / workspace-switch focus changes (mouse-cross-only focus
+  // updates require additional niri-side wiring, deferred).
+  const unsubCompositor = compositor.connect({
+    onFocusedWorkspaceChanged: () => {
+      refresh();
+    },
+    onFocusedWindowChanged: () => {
+      // In niri, mouse-cross fires WindowFocusChanged but not
+      // WorkspaceActivated. Re-resolving on window focus catches that case.
+      refresh();
+    },
+  });
+
+  // Service-driven popup events: a new notification needs to construct a
+  // row and register it with popup-state. Dismissals from elsewhere need
+  // to be reflected back into popup-state.
+  //
+  // Only one container should drive these — otherwise every monitor's
+  // view would race to build its own row for the same notification.
+  // Each container registers a "become driver" callback; the registry
+  // picks the first registered as active and promotes the next one when
+  // the active driver is destroyed (e.g. monitor hotplug).
+  let unsubService: (() => void) | null = null;
+  let unsubServiceMain: (() => void) | null = null;
+
+  const becomeDriver = (): void => {
+    unsubService = notificationService.subscribeToPopups((notification) => {
+      const row = PopupNotificationRow(notification);
+      addPopupGlobal({
+        notification,
+        widget: row.widget,
+        progress: row.progress,
+        cleanup: row.cleanup,
+      });
     });
 
-    popups.set(notification.id, popup);
-    container.append(popup);
-    checkAndNotify();
-  }
-
-  function removePopup(id: number): void {
-    const popup = popups.get(id);
-    if (!popup) return;
-
-    (popup as Gtk.Widget & { _cleanup?: () => void })._cleanup?.();
-    container.remove(popup);
-    popups.delete(id);
-    // Clear any sync-tag mapping that points at this id.
-    for (const [key, mappedId] of syncTagToId) {
-      if (mappedId === id) syncTagToId.delete(key);
-    }
-    checkAndNotify();
-  }
-
-  // Subscribe to new notifications
-  const unsubscribe = notificationService.subscribeToPopups((notification) => {
-    addPopup(notification);
-  });
-
-  // Also listen for dismissals
-  const unsubscribeMain = notificationService.subscribe(() => {
-    // Remove any popups that were dismissed externally on the server. Use
-    // hasLiveNotification() rather than getNotifications() so transient and
-    // synchronous-tagged popups (which are excluded from history) aren't
-    // wrongly torn down before their timeout completes.
-    for (const [id, _popup] of popups) {
-      if (!notificationService.hasLiveNotification(id)) {
-        removePopup(id);
+    unsubServiceMain = notificationService.subscribe(() => {
+      // Reflect external dismissals. Use hasLiveNotification so transient
+      // and sync-tagged popups (excluded from getNotifications()) aren't
+      // wrongly torn down before their timeout completes.
+      for (const p of getLivePopups()) {
+        if (!notificationService.hasLiveNotification(p.id)) {
+          removePopupGlobal(p.id);
+        }
       }
-    }
-  });
+    });
+  };
+
+  const unregisterDriverCandidate = registerDriverCandidate(becomeDriver);
+
+  // Initial state.
+  refresh();
 
   // Cleanup
   (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
-    // Clean up all popups
-    for (const [id, _popup] of popups) {
-      removePopup(id);
-    }
-    unsubscribe();
-    unsubscribeMain();
+    unsubPopups();
+    unsubCompositor();
+    unsubService?.();
+    unsubServiceMain?.();
+    unregisterDriverCandidate();
+    detachAll();
   };
 
   return container;
+}
+
+/* -----------------------------
+ * Driver election
+ *
+ * Exactly one container at a time owns the service subscriptions that
+ * mutate popup-state. Containers register a "become driver" callback at
+ * construction; the first registered is invoked immediately. On the active
+ * driver's cleanup, the next-registered candidate (FIFO) is promoted.
+ * This handles monitor hotplug: if the driver's monitor is unplugged, the
+ * next monitor's container takes over without missing notifications.
+ *
+ * A nicer design would put the service subscription inside popup-state
+ * itself, but that creates a chicken-and-egg with module load order; the
+ * driver-election model keeps popup-state pure data.
+ * ----------------------------- */
+
+type DriverCandidate = {
+  becomeDriver: () => void;
+  // Set when this candidate is the active driver; null otherwise.
+  // We don't currently need to dispose driver subscriptions here because
+  // the container's own _cleanup() runs the unsubs and then calls
+  // unregisterDriverCandidate() which advances to the next candidate.
+};
+
+const driverQueue: DriverCandidate[] = [];
+let activeDriver: DriverCandidate | null = null;
+
+function registerDriverCandidate(becomeDriver: () => void): () => void {
+  const candidate: DriverCandidate = { becomeDriver };
+  driverQueue.push(candidate);
+  if (activeDriver === null) {
+    activeDriver = candidate;
+    becomeDriver();
+  }
+  return () => {
+    const idx = driverQueue.indexOf(candidate);
+    if (idx !== -1) driverQueue.splice(idx, 1);
+    if (activeDriver === candidate) {
+      activeDriver = driverQueue[0] ?? null;
+      activeDriver?.becomeDriver();
+    }
+  };
 }

--- a/config/notifications/popup.tsx
+++ b/config/notifications/popup.tsx
@@ -1,5 +1,6 @@
 import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
+import { getCompositor } from "compositors";
 import { resolveNotificationIcon } from "helpers/icon-resolver";
 import {
   type NotificationData,
@@ -7,6 +8,62 @@ import {
 } from "services/notifications";
 
 const POPUP_TIMEOUT = 10000; // 10 seconds
+const PROGRESS_TICK_MS = 100; // shared scheduler cadence
+
+/* -----------------------------
+ * Shared progress scheduler
+ *
+ * One GLib source ticks every PROGRESS_TICK_MS and drives every live popup's
+ * progress bar. Previously each PopupNotification spawned its own 50ms timer,
+ * meaning N monitors × M popups × 20Hz wakeups. Now: a single 10Hz source for
+ * the whole app, regardless of popup count.
+ * ----------------------------- */
+
+interface SharedPopupEntry {
+  startTime: number; // GLib.get_monotonic_time() in microseconds
+  progress: Gtk.ProgressBar;
+  onTimeout: () => void;
+}
+
+const sharedPopups = new Set<SharedPopupEntry>();
+let sharedTimerId: number | null = null;
+
+function ensureSharedTimer(): void {
+  if (sharedTimerId !== null) return;
+  sharedTimerId = GLib.timeout_add(
+    GLib.PRIORITY_DEFAULT,
+    PROGRESS_TICK_MS,
+    () => {
+      // Iterate over a snapshot so onTimeout handlers can mutate the set.
+      const snapshot = Array.from(sharedPopups);
+      const now = GLib.get_monotonic_time();
+      for (const entry of snapshot) {
+        const elapsed = (now - entry.startTime) / 1000; // µs → ms
+        const remaining = Math.max(0, POPUP_TIMEOUT - elapsed);
+        entry.progress.fraction = remaining / POPUP_TIMEOUT;
+        if (remaining <= 0) {
+          sharedPopups.delete(entry);
+          entry.onTimeout();
+        }
+      }
+      if (sharedPopups.size === 0) {
+        sharedTimerId = null;
+        return GLib.SOURCE_REMOVE;
+      }
+      return GLib.SOURCE_CONTINUE;
+    },
+  );
+}
+
+function registerPopupProgress(entry: SharedPopupEntry): void {
+  sharedPopups.add(entry);
+  ensureSharedTimer();
+}
+
+function unregisterPopupProgress(entry: SharedPopupEntry): void {
+  sharedPopups.delete(entry);
+  // Timer is self-cancelling once the set empties; no need to remove here.
+}
 
 interface PopupNotificationProps {
   notification: NotificationData;
@@ -125,36 +182,31 @@ function PopupNotification(props: PopupNotificationProps): Gtk.Box {
 
   container.append(body);
 
-  // Timeout animation
-  let timeoutId: number | null = null;
-  const startTime = GLib.get_monotonic_time();
-  const updateProgress = (): boolean => {
-    const elapsed = (GLib.get_monotonic_time() - startTime) / 1000; // microseconds to milliseconds
-    const remaining = Math.max(0, POPUP_TIMEOUT - elapsed);
-    progress.fraction = remaining / POPUP_TIMEOUT;
-
-    if (remaining <= 0) {
-      onTimeout();
-      return false; // Stop the timeout
-    }
-
-    return true; // Continue
+  // Timeout animation — driven by the shared scheduler.
+  const entry: SharedPopupEntry = {
+    startTime: GLib.get_monotonic_time(),
+    progress,
+    onTimeout,
   };
-
-  timeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, updateProgress);
+  registerPopupProgress(entry);
 
   // Cleanup
   (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
-    if (timeoutId !== null) {
-      GLib.Source.remove(timeoutId);
-      timeoutId = null;
-    }
+    unregisterPopupProgress(entry);
   };
 
   return container;
 }
 
 interface PopupNotificationContainerProps {
+  /**
+   * Connector name of the monitor this container lives on (e.g. "DP-2").
+   * Used to gate popup creation to the focused monitor only.
+   * Resolved lazily by the caller — typically via `getMonitorConnectorName`
+   * once the parent window is realised. If null, the container accepts
+   * popups unconditionally (fallback: no focused-monitor info available).
+   */
+  getMonitorConnector?: () => string | null;
   onEmpty?: () => void;
   onHasNotifications?: () => void;
 }
@@ -162,6 +214,7 @@ interface PopupNotificationContainerProps {
 export function PopupNotificationContainer(
   props?: PopupNotificationContainerProps,
 ): Gtk.Box {
+  const compositor = getCompositor();
   const container = new Gtk.Box({
     orientation: Gtk.Orientation.VERTICAL,
     spacing: 8,
@@ -190,6 +243,17 @@ export function PopupNotificationContainer(
   function addPopup(notification: NotificationData): void {
     // Don't show duplicate popups
     if (popups.has(notification.id)) return;
+
+    // Focused-monitor gating: only the currently-focused monitor renders
+    // popups. Resolved at popup-arrival time; we don't migrate popups across
+    // monitors mid-lifetime. If we can't resolve our own connector or the
+    // compositor can't tell us the focused monitor, fall through and show
+    // the popup (best-effort fallback).
+    const ownConnector = props?.getMonitorConnector?.() ?? null;
+    const focused = compositor.getFocusedMonitor();
+    if (ownConnector !== null && focused !== null && ownConnector !== focused) {
+      return;
+    }
 
     // Synchronous-tag replacement: dismiss any prior popup that shares the
     // same (appName, syncTag) key before showing the new one.

--- a/config/notifications/popup.tsx
+++ b/config/notifications/popup.tsx
@@ -169,6 +169,14 @@ export function PopupNotificationContainer(
   });
 
   const popups = new Map<number, Gtk.Widget>();
+  // Track currently-shown popup id per (appName + syncTag) so a follow-up
+  // notification with the same tag replaces the existing popup instead of
+  // stacking. This is what makes volume / brightness OSDs feel right.
+  const syncTagToId = new Map<string, number>();
+
+  function syncKey(appName: string, tag: string): string {
+    return `${appName}\x00${tag}`;
+  }
 
   function checkAndNotify(): void {
     if (popups.size === 0) {
@@ -183,13 +191,29 @@ export function PopupNotificationContainer(
     // Don't show duplicate popups
     if (popups.has(notification.id)) return;
 
+    // Synchronous-tag replacement: dismiss any prior popup that shares the
+    // same (appName, syncTag) key before showing the new one.
+    if (notification.syncTag !== null) {
+      const key = syncKey(notification.appName, notification.syncTag);
+      const priorId = syncTagToId.get(key);
+      if (priorId !== undefined && priorId !== notification.id) {
+        // Mirror what the user pressing "close" does — remove from the
+        // server too so the prior notification doesn't linger as resolved
+        // history elsewhere.
+        notificationService.dismissDuringPopup(priorId);
+        removePopup(priorId);
+      }
+      syncTagToId.set(key, notification.id);
+    }
+
     const popup = PopupNotification({
       notification,
       onDismiss: () => {
         removePopup(notification.id);
       },
       onTimeout: () => {
-        // Timeout means it should go to history
+        // Timeout means it should go to history (unless transient/sync-tagged
+        // — the service has already excluded those from getNotifications()).
         removePopup(notification.id);
       },
     });
@@ -206,6 +230,10 @@ export function PopupNotificationContainer(
     (popup as Gtk.Widget & { _cleanup?: () => void })._cleanup?.();
     container.remove(popup);
     popups.delete(id);
+    // Clear any sync-tag mapping that points at this id.
+    for (const [key, mappedId] of syncTagToId) {
+      if (mappedId === id) syncTagToId.delete(key);
+    }
     checkAndNotify();
   }
 
@@ -216,12 +244,12 @@ export function PopupNotificationContainer(
 
   // Also listen for dismissals
   const unsubscribeMain = notificationService.subscribe(() => {
-    // Remove any popups that were dismissed externally
+    // Remove any popups that were dismissed externally on the server. Use
+    // hasLiveNotification() rather than getNotifications() so transient and
+    // synchronous-tagged popups (which are excluded from history) aren't
+    // wrongly torn down before their timeout completes.
     for (const [id, _popup] of popups) {
-      const exists = notificationService
-        .getNotifications()
-        .some((n) => n.id === id);
-      if (!exists) {
+      if (!notificationService.hasLiveNotification(id)) {
         removePopup(id);
       }
     }

--- a/config/package.json
+++ b/config/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "fred-bar-config",
+  "private": true,
+  "description": "TypeScript dependencies for the fred-bar ags config. The runtime is provided by the ags CLI (which bundles its own ags/gnim); npm here only serves tsc for typechecking.",
+  "dependencies": {
+    "ags": "*",
+    "gnim": "*"
+  }
+}

--- a/config/right/battery/battery.tsx
+++ b/config/right/battery/battery.tsx
@@ -1,5 +1,6 @@
 import Battery from "gi://AstalBattery";
 import Gtk from "gi://Gtk?version=4.0";
+import { registerCleanup } from "helpers/cleanup";
 
 import { attachTooltip } from "helpers/tooltip";
 
@@ -189,12 +190,12 @@ export function BatteryPill(): Gtk.Box {
    * Cleanup
    * ----------------------------- */
 
-  (box as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  registerCleanup(box, () => {
     battery.disconnect(chargingHandler);
     battery.disconnect(energyHandler);
     battery.disconnect(stateHandler);
     battery.disconnect(presentHandler);
-  };
+  });
 
   return box;
 }

--- a/config/right/battery/battery.tsx
+++ b/config/right/battery/battery.tsx
@@ -1,4 +1,5 @@
 import Battery from "gi://AstalBattery";
+import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 
 import { attachTooltip } from "helpers/tooltip";
@@ -143,8 +144,14 @@ export function BatteryPill(): Gtk.Box {
   const energyHandler = battery.connect("notify::energy", update);
   const stateHandler = battery.connect("notify::state", update);
 
-  // Poll every 2 seconds to catch state changes that don't fire events
-  const pollInterval = setInterval(update, 2000);
+  // Poll every 2 seconds to catch state changes that don't fire events.
+  // Use GLib.timeout_add directly (rather than ags' setInterval shim) so
+  // the source is GLib-priority-aware and survives suspend/resume cycles
+  // consistent with the rest of the bar's long-running pollers.
+  const pollInterval = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2000, () => {
+    update();
+    return GLib.SOURCE_CONTINUE;
+  });
 
   /* -----------------------------
    * Tooltip (shares pill class)
@@ -188,7 +195,7 @@ export function BatteryPill(): Gtk.Box {
     battery.disconnect(chargingHandler);
     battery.disconnect(energyHandler);
     battery.disconnect(stateHandler);
-    clearInterval(pollInterval);
+    GLib.Source.remove(pollInterval);
   };
 
   return box;

--- a/config/right/battery/battery.tsx
+++ b/config/right/battery/battery.tsx
@@ -1,5 +1,4 @@
 import Battery from "gi://AstalBattery";
-import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 
 import { attachTooltip } from "helpers/tooltip";
@@ -140,18 +139,17 @@ export function BatteryPill(): Gtk.Box {
   }
 
   update();
+  // UPower emits notify::* for every property change, and AstalBattery
+  // proxies those through to the GObject. Subscribing to the properties
+  // we actually display is sufficient to keep the widget in sync; the
+  // earlier 2-second poll was a cargo-culted workaround for a UPower
+  // notification gap that has not been observed on current systems.
+  // The tooltip callback re-evaluates on every hover, so dynamic values
+  // (time_to_empty, energy_rate) refresh naturally without polling.
   const chargingHandler = battery.connect("notify::charging", update);
   const energyHandler = battery.connect("notify::energy", update);
   const stateHandler = battery.connect("notify::state", update);
-
-  // Poll every 2 seconds to catch state changes that don't fire events.
-  // Use GLib.timeout_add directly (rather than ags' setInterval shim) so
-  // the source is GLib-priority-aware and survives suspend/resume cycles
-  // consistent with the rest of the bar's long-running pollers.
-  const pollInterval = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2000, () => {
-    update();
-    return GLib.SOURCE_CONTINUE;
-  });
+  const presentHandler = battery.connect("notify::is-present", update);
 
   /* -----------------------------
    * Tooltip (shares pill class)
@@ -195,7 +193,7 @@ export function BatteryPill(): Gtk.Box {
     battery.disconnect(chargingHandler);
     battery.disconnect(energyHandler);
     battery.disconnect(stateHandler);
-    GLib.Source.remove(pollInterval);
+    battery.disconnect(presentHandler);
   };
 
   return box;

--- a/config/right/network/network.tsx
+++ b/config/right/network/network.tsx
@@ -1,6 +1,7 @@
 import Network from "gi://AstalNetwork";
 import Gtk from "gi://Gtk?version=4.0";
 
+import { registerCleanup } from "helpers/cleanup";
 import { attachTooltip } from "helpers/tooltip";
 import { subscribeVpn, type VpnStatus } from "services/vpn";
 
@@ -253,7 +254,7 @@ export function NetworkPill(): Gtk.Box {
    * Cleanup - disconnect signal handlers
    * ----------------------------- */
 
-  (box as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  registerCleanup(box, () => {
     // Disconnect GObject signal handlers to prevent memory leaks
     if (network.wifi) {
       for (const id of wifiHandlers) network.wifi.disconnect(id);
@@ -262,7 +263,7 @@ export function NetworkPill(): Gtk.Box {
       for (const id of wiredHandlers) network.wired.disconnect(id);
     }
     unsubscribeVpn();
-  };
+  });
 
   return box;
 }

--- a/config/right/network/network.tsx
+++ b/config/right/network/network.tsx
@@ -248,6 +248,7 @@ export function NetworkPill(): Gtk.Box {
 
     // Tooltip inherits the pill's state class for consistent theming
     classes: () => [currentClass],
+    updateInterval: 1000,
   });
 
   /* -----------------------------

--- a/config/right/network/network.tsx
+++ b/config/right/network/network.tsx
@@ -201,8 +201,11 @@ export function NetworkPill(): Gtk.Box {
   const wifiHandler = network.wifi?.connect("notify", update);
   const wiredHandler = network.wired?.connect("notify", update);
 
-  // Poll VPN status every 3 seconds since AstalNetwork doesn't expose VPN
-  const vpnPollInterval = setInterval(() => {
+  // Poll VPN status every 3 seconds since AstalNetwork doesn't expose VPN.
+  // Use GLib.timeout_add (not the ags setInterval shim) for GLib priority
+  // semantics and consistent suspend/resume behavior. C-3.1 will move VPN
+  // detection out of this widget into a shared service.
+  const vpnPollInterval = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 3000, () => {
     const newVpnStatus = checkVpnStatus();
     if (
       newVpnStatus.active !== vpnStatus.active ||
@@ -210,7 +213,8 @@ export function NetworkPill(): Gtk.Box {
     ) {
       update();
     }
-  }, 3000);
+    return GLib.SOURCE_CONTINUE;
+  });
 
   /* -----------------------------
    * Tooltip
@@ -279,7 +283,7 @@ export function NetworkPill(): Gtk.Box {
     if (wiredHandler && network.wired) {
       network.wired.disconnect(wiredHandler);
     }
-    clearInterval(vpnPollInterval);
+    GLib.Source.remove(vpnPollInterval);
   };
 
   return box;

--- a/config/right/network/network.tsx
+++ b/config/right/network/network.tsx
@@ -1,8 +1,8 @@
 import Network from "gi://AstalNetwork";
-import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 
 import { attachTooltip } from "helpers/tooltip";
+import { subscribeVpn, type VpnStatus } from "services/vpn";
 
 /* -----------------------------
  * Network Widget - AstalNetwork Integration
@@ -55,44 +55,13 @@ function vpnIcon(): string {
 }
 
 /**
- * Checks if a VPN connection is active using nmcli
- * @returns Object with VPN status and connection name
- */
-function checkVpnStatus(): { active: boolean; name: string } {
-  try {
-    const [success, stdout] = GLib.spawn_command_line_sync(
-      "nmcli -t -f NAME,TYPE connection show --active",
-    );
-
-    if (!success || !stdout) {
-      return { active: false, name: "" };
-    }
-
-    const decoder = new TextDecoder();
-    const output = decoder.decode(stdout);
-    const lines = output.split("\n");
-
-    for (const line of lines) {
-      const [name, type] = line.split(":");
-      if (type === "vpn") {
-        return { active: true, name: name || "VPN" };
-      }
-    }
-
-    return { active: false, name: "" };
-  } catch (_e) {
-    return { active: false, name: "" };
-  }
-}
-
-/**
  * Determines current network state and returns display info
  * @param network - AstalNetwork.Network instance
  * @returns Object with icon, label, and connection status
  */
 function getNetworkInfo(
   network: Network.Network,
-  vpnStatus: { active: boolean; name: string },
+  vpnStatus: VpnStatus,
 ): {
   icon: string;
   connected: boolean;
@@ -160,8 +129,8 @@ export function NetworkPill(): Gtk.Box {
   // Track current CSS class for tooltip theming
   let currentClass = "network-connected";
 
-  // Track VPN status
-  let vpnStatus = checkVpnStatus();
+  // VPN status maintained via shared service (no per-widget polling).
+  let vpnStatus: VpnStatus = { active: false, name: "" };
 
   // Create container box with pill styling
   const box = new Gtk.Box({
@@ -177,9 +146,6 @@ export function NetworkPill(): Gtk.Box {
    * Updates widget display based on current network state
    */
   function update(): void {
-    // Check VPN status
-    vpnStatus = checkVpnStatus();
-
     const info = getNetworkInfo(network, vpnStatus);
 
     icon.label = info.icon;
@@ -193,27 +159,39 @@ export function NetworkPill(): Gtk.Box {
     box.add_css_class(currentClass);
   }
 
-  // Initial render
+  // Initial render (empty VPN state until first poll completes; service
+  // fires our callback synchronously on subscribe with the cached value
+  // and again when it changes).
   update();
 
-  // Subscribe to network state changes (GObject signals)
-  // These fire automatically when network properties change
-  const wifiHandler = network.wifi?.connect("notify", update);
-  const wiredHandler = network.wired?.connect("notify", update);
+  // Subscribe to network state changes (GObject signals).
+  // Narrow `notify` to the properties that actually affect what we
+  // render. The bare `notify` signal fires on *any* property change —
+  // including `strength` jitter every few seconds when on WiFi — and
+  // each emit triggers a full update. Listening per-property cuts the
+  // wakeup rate by an order of magnitude. See AUDIT C-1.5.
+  const wifiHandlers = network.wifi
+    ? [
+        network.wifi.connect("notify::ssid", update),
+        network.wifi.connect("notify::strength", update),
+        network.wifi.connect("notify::internet", update),
+        network.wifi.connect("notify::active-access-point", update),
+        network.wifi.connect("notify::frequency", update),
+        network.wifi.connect("notify::enabled", update),
+      ]
+    : [];
+  const wiredHandlers = network.wired
+    ? [
+        network.wired.connect("notify::internet", update),
+        network.wired.connect("notify::state", update),
+        network.wired.connect("notify::speed", update),
+      ]
+    : [];
 
-  // Poll VPN status every 3 seconds since AstalNetwork doesn't expose VPN.
-  // Use GLib.timeout_add (not the ags setInterval shim) for GLib priority
-  // semantics and consistent suspend/resume behavior. C-3.1 will move VPN
-  // detection out of this widget into a shared service.
-  const vpnPollInterval = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 3000, () => {
-    const newVpnStatus = checkVpnStatus();
-    if (
-      newVpnStatus.active !== vpnStatus.active ||
-      newVpnStatus.name !== vpnStatus.name
-    ) {
-      update();
-    }
-    return GLib.SOURCE_CONTINUE;
+  // Subscribe to centralised VPN service (see services/vpn.tsx).
+  const unsubscribeVpn = subscribeVpn((status) => {
+    vpnStatus = status;
+    update();
   });
 
   /* -----------------------------
@@ -277,13 +255,13 @@ export function NetworkPill(): Gtk.Box {
 
   (box as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
     // Disconnect GObject signal handlers to prevent memory leaks
-    if (wifiHandler && network.wifi) {
-      network.wifi.disconnect(wifiHandler);
+    if (network.wifi) {
+      for (const id of wifiHandlers) network.wifi.disconnect(id);
     }
-    if (wiredHandler && network.wired) {
-      network.wired.disconnect(wiredHandler);
+    if (network.wired) {
+      for (const id of wiredHandlers) network.wired.disconnect(id);
     }
-    GLib.Source.remove(vpnPollInterval);
+    unsubscribeVpn();
   };
 
   return box;

--- a/config/right/speaker-volume/volume.tsx
+++ b/config/right/speaker-volume/volume.tsx
@@ -2,6 +2,7 @@ import Wp from "gi://AstalWp";
 import Gdk from "gi://Gdk?version=4.0";
 import Gtk from "gi://Gtk?version=4.0";
 
+import { registerCleanup } from "helpers/cleanup";
 import { attachTooltip } from "helpers/tooltip";
 
 /* -----------------------------
@@ -264,7 +265,7 @@ export function VolumePill(): Gtk.Box {
    * Cleanup - disconnect signal handlers
    * ----------------------------- */
 
-  (box as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  registerCleanup(box, () => {
     // Disconnect audio-level signals
     audio.disconnect(speakerChangedId);
 
@@ -275,7 +276,7 @@ export function VolumePill(): Gtk.Box {
         speaker.disconnect(id);
       });
     }
-  };
+  });
 
   return box;
 }

--- a/config/right/speaker-volume/volume.tsx
+++ b/config/right/speaker-volume/volume.tsx
@@ -164,9 +164,6 @@ export function VolumePill(): Gtk.Box {
   // Initial render
   update();
 
-  // Listen for default speaker changes (device hotplug)
-  const speakerChangedId = audio.connect("notify::default-speaker", update);
-
   // Track signal handlers for current speaker
   let currentSpeakerHandlers: number[] = [];
 
@@ -197,8 +194,11 @@ export function VolumePill(): Gtk.Box {
   // Initial connection to current speaker
   connectSpeakerSignals();
 
-  // Reconnect when default speaker changes (e.g., plugging in headphones)
-  audio.connect("notify::default-speaker", () => {
+  // Reconnect when default speaker changes (e.g., plugging in headphones).
+  // A single handler covers both "rewire signals to the new device" and
+  // "redraw the pill" — a previously-existing duplicate audio.connect that
+  // only called update() leaked its handler id and doubled the work.
+  const speakerChangedId = audio.connect("notify::default-speaker", () => {
     connectSpeakerSignals();
     update();
   });

--- a/config/right/system/state-pill.tsx
+++ b/config/right/system/state-pill.tsx
@@ -1,5 +1,6 @@
 import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
+import { registerCleanup } from "helpers/cleanup";
 import { attachTooltip } from "helpers/tooltip";
 import { notificationService } from "services/notifications";
 import { getWindowManager } from "services/window-manager";
@@ -175,9 +176,9 @@ export function StatePill(): Gtk.Button {
   });
 
   // Cleanup hook
-  (button as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  registerCleanup(button, () => {
     unsubscribe();
-  };
+  });
 
   return button;
 }

--- a/config/right/system/state-pill.tsx
+++ b/config/right/system/state-pill.tsx
@@ -73,8 +73,13 @@ export function StatePill(): Gtk.Button {
       }
     }
 
-    // Toggle sidebar window using window manager
+    // Toggle sidebar window using window manager.
+    // Register this button as the sidebar's owner so the bar-level click gate
+    // (in app.tsx) can detect "click on the state-pill that owns the open
+    // sidebar" and skip dismissal — letting the toggle below close it instead
+    // of dismiss-then-reopen. Cheap; idempotent on repeat clicks.
     const sidebarName = `sidebar-${monitorIndex}`;
+    windowManager.setOwner(sidebarName, button);
     windowManager.toggle(sidebarName);
   });
 

--- a/config/right/system/state/modules/idleInhibit.tsx
+++ b/config/right/system/state/modules/idleInhibit.tsx
@@ -1,7 +1,10 @@
 import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import { createPoll } from "ags/time";
+import { createLogger } from "helpers/logger";
 import type { Severity, SystemSignal } from "../helpers/normalize";
+
+const log = createLogger("IdleInhibit");
 
 /* -----------------------------
  * Idle Inhibit Detection - D-Bus Integration
@@ -138,7 +141,7 @@ function getInhibitors(): Inhibitor[] {
 
     return inhibitors;
   } catch (error) {
-    console.error("Failed to query systemd-logind inhibitors:", error);
+    log.error("Failed to query systemd-logind inhibitors:", error);
     return [];
   }
 }

--- a/config/right/system/state/modules/media.tsx
+++ b/config/right/system/state/modules/media.tsx
@@ -14,7 +14,7 @@ function getMediaSignal(): SystemSignal | null {
 
   // Check for active microphone (Audio/Source)
   if (audio) {
-    const activeMic = audio.recorders.find((recorder) => recorder.volume > 0);
+    const activeMic = audio.recorders?.find((recorder) => recorder.volume > 0);
     if (activeMic) {
       return {
         severity: "info",
@@ -51,7 +51,7 @@ function getMediaSignal(): SystemSignal | null {
 
   // Check for audio playback (Audio/Sink streams)
   if (audio) {
-    const activeStream = audio.streams.find((stream) => stream.volume > 0);
+    const activeStream = audio.streams?.find((stream) => stream.volume > 0);
     if (activeStream) {
       return {
         severity: "info",

--- a/config/right/system/state/modules/system.tsx
+++ b/config/right/system/state/modules/system.tsx
@@ -16,12 +16,58 @@ const INITIAL: AggregatedSystemState = {
   sources: [],
 };
 
-export const systemState = createPoll<AggregatedSystemState>(INITIAL, 250, () =>
-  resolveSystemState([
-    idleInhibitState(),
-    mediaState(),
-    updateState(),
-    networkState(),
-    notificationState(),
-  ]),
+/**
+ * Compare two AggregatedSystemState objects for material equality so the
+ * underlying createPoll's reference-identity check can suppress no-op
+ * subscriber notifications.
+ *
+ * The poll fires 4×/sec; without this dedup every consumer (state-pill,
+ * tooltip text, etc.) would rebuild widgets four times a second even when
+ * nothing changed. The aggregator's `sources` array is treated as
+ * material — its SystemSignal entries are compared by category, severity,
+ * icon and summary so unrelated module reshuffles don't trip the diff.
+ */
+function statesEqual(
+  a: AggregatedSystemState,
+  b: AggregatedSystemState,
+): boolean {
+  if (a === b) return true;
+  if (a.severity !== b.severity) return false;
+  if (a.icon !== b.icon) return false;
+  if (a.summary !== b.summary) return false;
+  if (a.icons.length !== b.icons.length) return false;
+  for (let i = 0; i < a.icons.length; i++) {
+    if (a.icons[i] !== b.icons[i]) return false;
+  }
+  if (a.sources.length !== b.sources.length) return false;
+  for (let i = 0; i < a.sources.length; i++) {
+    const sa = a.sources[i];
+    const sb = b.sources[i];
+    if (
+      sa.category !== sb.category ||
+      sa.severity !== sb.severity ||
+      sa.icon !== sb.icon ||
+      sa.summary !== sb.summary
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export const systemState = createPoll<AggregatedSystemState>(
+  INITIAL,
+  250,
+  (prev) => {
+    const next = resolveSystemState([
+      idleInhibitState(),
+      mediaState(),
+      updateState(),
+      networkState(),
+      notificationState(),
+    ]);
+    // Returning prev (reference-equal) prevents createPoll from notifying
+    // subscribers — see ags/time.ts createPoll set() reference check.
+    return statesEqual(prev, next) ? prev : next;
+  },
 );

--- a/config/right/time-pill/calendar-service.tsx
+++ b/config/right/time-pill/calendar-service.tsx
@@ -37,6 +37,15 @@ export class CalendarService {
   private isApiAvailable = false;
   private currentDateOffset = 0; // 0 = today, 1 = tomorrow, -1 = yesterday, etc.
 
+  /**
+   * Monotonically increasing request id. Each fetch captures the id at
+   * call site; the async completion compares against the latest before
+   * applying its result. This prevents stale fetches from overwriting
+   * fresh ones when the user navigates rapidly via previousDay()/
+   * nextDay() (taps faster than network round-trip). See AUDIT C-1.4.
+   */
+  private latestRequestId = 0;
+
   constructor() {
     // Start fetching immediately
     this.fetchCalendarData();
@@ -136,6 +145,10 @@ export class CalendarService {
   }
 
   private performFetch(): void {
+    // Capture this fetch's id; the async callback will compare it
+    // against `latestRequestId` and bail if a newer fetch has started.
+    const requestId = ++this.latestRequestId;
+
     try {
       const currentDate = this.getCurrentDate();
       const _dateStr = currentDate ? currentDate.format("%Y-%m-%d") : "unknown";
@@ -144,6 +157,11 @@ export class CalendarService {
       const file = Gio.File.new_for_uri(apiUrl);
 
       file.load_contents_async(null, (source, result) => {
+        if (requestId !== this.latestRequestId) {
+          // A newer fetch has been issued; this response is stale.
+          return;
+        }
+
         try {
           if (!source) {
             this.handleFetchError("Source is null");

--- a/config/right/time-pill/calendar-service.tsx
+++ b/config/right/time-pill/calendar-service.tsx
@@ -2,6 +2,9 @@
 
 import Gio from "gi://Gio";
 import GLib from "gi://GLib";
+import { createLogger } from "helpers/logger";
+
+const log = createLogger("CalendarService");
 
 const CALENDAR_API_BASE_URL = "http://localhost:5090/api";
 const RETRY_INTERVAL_MS = 60000; // 1 minute when API is unavailable
@@ -194,7 +197,7 @@ export class CalendarService {
   }
 
   private handleFetchError(message: string): void {
-    console.warn(`[CalendarService] ${message}`);
+    log.warn(message);
 
     if (this.isApiAvailable) {
       // API was available but failed - might be temporary
@@ -227,7 +230,7 @@ export class CalendarService {
       try {
         callback(this.data);
       } catch (error) {
-        console.error("[CalendarService] Error in callback:", error);
+        log.error("Error in callback:", error);
       }
     }
   }

--- a/config/right/time-pill/calendar-view.tsx
+++ b/config/right/time-pill/calendar-view.tsx
@@ -2,8 +2,11 @@
 
 import GLib from "gi://GLib?version=2.0";
 import Gtk from "gi://Gtk?version=4.0";
+import { createLogger } from "helpers/logger";
 import type { CalendarData, CalendarEvent } from "./calendar-service";
 import { getCalendarService } from "./calendar-service";
+
+const log = createLogger("CalendarView");
 
 /**
  * Catppuccin Mocha Color Palette (colorful colors only)
@@ -228,7 +231,7 @@ function applyCalendarColor(
       .get_style_context()
       .add_provider(cssProvider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
   } catch (error) {
-    console.error("Failed to apply CSS:", error);
+    log.error("Failed to apply CSS:", error);
   }
 }
 
@@ -248,7 +251,7 @@ function parseDateTime(isoString: string): GLib.DateTime | null {
       return utcDt.to_local();
     }
   } catch (error) {
-    console.error(`Failed to parse date: ${isoString}`, error);
+    log.error(`Failed to parse date: ${isoString}`, error);
   }
   return null;
 }

--- a/config/right/time-pill/time-pill.tsx
+++ b/config/right/time-pill/time-pill.tsx
@@ -31,8 +31,13 @@ function nowIn(tzid: string): GLib.DateTime | null {
   }
 }
 
-export function TimePill(): Gtk.Button {
+export function TimePill({
+  monitorIndex,
+}: {
+  monitorIndex: number;
+}): Gtk.Button {
   const windowManager = getWindowManager();
+  const windowName = `time-pill-calendar-${monitorIndex}`;
   let hovered = false;
   let expanded = false;
   let windowOpen = false;
@@ -88,13 +93,27 @@ export function TimePill(): Gtk.Button {
 
   const timeWindow = (
     <window
-      name="time-pill-calendar"
+      name={windowName}
       visible={false}
+      monitor={monitorIndex}
       anchor={TOP | RIGHT}
       class="time-window"
       exclusivity={Astal.Exclusivity.NORMAL}
       layer={Astal.Layer.OVERLAY}
-      keymode={Astal.Keymode.ON_DEMAND}
+      // Keymode.NONE (not ON_DEMAND). With ON_DEMAND, hyprland (or
+      // gtk4-layer-shell on its behalf) requests keyboard interactivity
+      // on map, which the compositor implements by transferring the
+      // implicit pointer grab to the new surface. The bar surface
+      // then receives `pointer.leave`, and subsequent clicks on the
+      // pill are not delivered to the button widget until the cursor
+      // moves again. With NONE, the calendar takes no keyboard
+      // interactivity, the bar keeps its pointer grab, and "click
+      // pill again to dismiss without moving the mouse" works.
+      // Trade-off: ESC-to-dismiss won't work via the window's own
+      // key controller. If we need ESC handling later, attach a
+      // global key-snooper on the application root rather than
+      // re-introducing keyboard interactivity on this window.
+      keymode={Astal.Keymode.NONE}
     />
   ) as unknown as Gtk.Window;
 
@@ -286,23 +305,31 @@ export function TimePill(): Gtk.Button {
 
   // Create backdrop window for click-outside-to-close
   const _backdrop = setupBackdrop(timeWindow, () => {
-    windowManager.hide("time-pill-calendar");
+    windowManager.hide(windowName);
   });
 
-  // Register with window manager and provide deactivation callback
-  windowManager.register("time-pill-calendar", timeWindow, () => {
-    // When another window opens, collapse the label if window isn't actually open
-    if (!windowOpen && expanded) {
-      applyExpanded(false);
-    }
-  });
+  // Register with window manager and provide deactivation callback.
+  // Owner = the pill button; lets the bar-level click gate detect "click on
+  // the pill that owns this open panel" and skip dismissal so the pill's own
+  // toggle handler can close it.
+  windowManager.register(
+    windowName,
+    timeWindow,
+    () => {
+      // When another window opens, collapse the label if window isn't actually open
+      if (!windowOpen && expanded) {
+        applyExpanded(false);
+      }
+    },
+    button,
+  );
 
   // Handle ESC key to close
   const keyController = new Gtk.EventControllerKey();
   keyController.connect("key-pressed", (_ctrl, keyval) => {
     if (keyval === 65307) {
       // ESC key
-      windowManager.hide("time-pill-calendar");
+      windowManager.hide(windowName);
       return true;
     }
     return false;
@@ -504,7 +531,7 @@ export function TimePill(): Gtk.Button {
   button.connect("clicked", () => {
     if (windowOpen) {
       windowOpen = false;
-      windowManager.hide("time-pill-calendar");
+      windowManager.hide(windowName);
       return;
     }
 
@@ -515,7 +542,7 @@ export function TimePill(): Gtk.Button {
     applyExpanded(true);
 
     GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
-      windowManager.show("time-pill-calendar");
+      windowManager.show(windowName);
       updateLabels();
       return GLib.SOURCE_REMOVE;
     });

--- a/config/right/time-pill/time-pill.tsx
+++ b/config/right/time-pill/time-pill.tsx
@@ -6,6 +6,7 @@ import { Astal } from "ags/gtk4";
 import type Cairo from "cairo";
 import { setupBackdrop } from "helpers/backdrop";
 import { registerCleanup } from "helpers/cleanup";
+import { asWindow } from "helpers/jsx";
 import { attachTooltip } from "helpers/tooltip";
 import { getWindowManager } from "services/window-manager";
 import { CalendarView } from "./calendar-view";
@@ -92,7 +93,7 @@ export function TimePill({
 
   const { TOP, RIGHT } = Astal.WindowAnchor;
 
-  const timeWindow = (
+  const timeWindow = asWindow(
     <window
       name={windowName}
       visible={false}
@@ -115,8 +116,8 @@ export function TimePill({
       // global key-snooper on the application root rather than
       // re-introducing keyboard interactivity on this window.
       keymode={Astal.Keymode.NONE}
-    />
-  ) as unknown as Gtk.Window;
+    />,
+  );
 
   const popRoot = new Gtk.Box({
     orientation: Gtk.Orientation.VERTICAL,

--- a/config/right/time-pill/time-pill.tsx
+++ b/config/right/time-pill/time-pill.tsx
@@ -5,6 +5,7 @@ import Gtk from "gi://Gtk?version=4.0";
 import { Astal } from "ags/gtk4";
 import type Cairo from "cairo";
 import { setupBackdrop } from "helpers/backdrop";
+import { registerCleanup } from "helpers/cleanup";
 import { attachTooltip } from "helpers/tooltip";
 import { getWindowManager } from "services/window-manager";
 import { CalendarView } from "./calendar-view";
@@ -556,14 +557,14 @@ export function TimePill({
 
   /* ───────── Cleanup ───────── */
 
-  (button as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  registerCleanup(button, () => {
     if (expandTimeoutId !== null) GLib.source_remove(expandTimeoutId);
     if (collapseTimeoutId !== null) GLib.source_remove(collapseTimeoutId);
     if (tickTimeoutId !== null) {
       GLib.source_remove(tickTimeoutId);
       tickTimeoutId = null;
     }
-  };
+  });
 
   return button;
 }

--- a/config/right/time-pill/time-pill.tsx
+++ b/config/right/time-pill/time-pill.tsx
@@ -144,8 +144,16 @@ export function TimePill({
   popRoot.append(title);
   popRoot.append(clocksGrid);
 
-  const clockDrawingAreas = new Map<string, Gtk.DrawingArea>();
-  const clockBoxes = new Map<string, Gtk.Box>();
+  // Keyed by clock label (guaranteed unique in CLOCKS) rather than tzid:
+  // the local clock has tzid="" and any second empty-tzid entry would
+  // silently overwrite. Value bundles the area, box, and tzid together
+  // so the redraw loop has everything it needs without a parallel map.
+  type ClockEntry = {
+    area: Gtk.DrawingArea;
+    box: Gtk.Box;
+    tzid: string;
+  };
+  const clockEntries = new Map<string, ClockEntry>();
 
   let clockIndex = 0;
 
@@ -275,8 +283,7 @@ export function TimePill({
     const row = Math.floor(clockIndex / 3);
     clocksGrid.attach(line, col, row, 1, 1);
 
-    clockDrawingAreas.set(c.tzid, clockArea);
-    clockBoxes.set(c.tzid, line);
+    clockEntries.set(c.label, { area: clockArea, box: line, tzid: c.tzid });
 
     // Attach tooltip with live updates
     attachTooltip(line, {
@@ -414,21 +421,18 @@ export function TimePill({
 
     // Window clocks
     if (windowOpen) {
-      for (const [tzid, area] of clockDrawingAreas.entries()) {
+      for (const { area, box, tzid } of clockEntries.values()) {
         const dt = nowIn(tzid);
 
         // Apply day/night styling
-        const box = clockBoxes.get(tzid);
-        if (box && dt) {
+        if (dt) {
           box.remove_css_class("daytime");
           box.remove_css_class("nighttime");
           box.add_css_class(isDaytime(dt) ? "daytime" : "nighttime");
         }
 
         // Redraw the clock
-        if (area) {
-          area.queue_draw();
-        }
+        area.queue_draw();
       }
     }
   }

--- a/config/services/compositor-detect.tsx
+++ b/config/services/compositor-detect.tsx
@@ -1,0 +1,77 @@
+import GLib from "gi://GLib";
+
+import { runAsync } from "helpers/subprocess";
+
+/**
+ * Compositor identity detection.
+ *
+ * Previously each consumer (system-actions.tsx) ran three synchronous
+ * `pgrep -x` invocations on the GTK main thread on every construction —
+ * up to three sub-second hangs per sidebar open. The compositor doesn't
+ * change at runtime, so detection happens exactly once at module load:
+ *
+ * 1. Inspect `XDG_CURRENT_DESKTOP` (cheap, deterministic, no fork).
+ * 2. If unknown, asynchronously fall back to `pgrep -x` for known
+ *    compositors. Falls into `runAsync` so the main loop never blocks.
+ *
+ * Until step 2 resolves, `getCompositorKind()` returns `"unknown"`.
+ * Consumers that need to defer until detection completes can `await`
+ * `compositorReady`.
+ *
+ * See AUDIT C-1.9 / C-3.1.
+ */
+
+export type CompositorKind = "hyprland" | "niri" | "sway" | "unknown";
+
+let kind: CompositorKind = "unknown";
+
+function fromEnv(): CompositorKind {
+  const session = (GLib.getenv("XDG_CURRENT_DESKTOP") || "").toLowerCase();
+  if (session.includes("hyprland")) return "hyprland";
+  if (session.includes("niri")) return "niri";
+  if (session.includes("sway")) return "sway";
+  return "unknown";
+}
+
+async function detectViaPgrep(): Promise<CompositorKind> {
+  // Run probes in parallel; first non-empty stdout wins.
+  const probes: Array<[CompositorKind, Promise<string | null>]> = [
+    ["hyprland", runAsync(["pgrep", "-x", "Hyprland"])],
+    ["niri", runAsync(["pgrep", "-x", "niri"])],
+    ["sway", runAsync(["pgrep", "-x", "sway"])],
+  ];
+  for (const [name, p] of probes) {
+    const out = await p;
+    if (out && out.trim().length > 0) return name;
+  }
+  return "unknown";
+}
+
+/**
+ * Resolves once detection is finished. Most consumers don't need to
+ * await it; `getCompositorKind()` is safe to call any time and simply
+ * returns the best guess available so far.
+ */
+export const compositorReady: Promise<CompositorKind> = (async () => {
+  kind = fromEnv();
+  if (kind !== "unknown") return kind;
+  kind = await detectViaPgrep();
+  return kind;
+})();
+
+export function getCompositorKind(): CompositorKind {
+  return kind;
+}
+
+export function getCompositorExitCommand(): string[] | null {
+  switch (getCompositorKind()) {
+    case "hyprland":
+      return ["setsid", "hyprshutdown"];
+    case "niri":
+      return ["niri", "msg", "action", "quit"];
+    case "sway":
+      return ["swaymsg", "exit"];
+    default:
+      return null;
+  }
+}

--- a/config/services/notifications.tsx
+++ b/config/services/notifications.tsx
@@ -9,6 +9,17 @@ export interface NotificationData {
   body: string;
   time: number;
   urgency: number;
+  /**
+   * freedesktop spec `transient` hint. When true the notification must not be
+   * added to persistent history (popup-only).
+   */
+  transient: boolean;
+  /**
+   * Canonical extension `x-canonical-private-synchronous`. Notifications
+   * sharing the same tag (per appName) replace each other and never persist.
+   * Used by volume / brightness OSDs.
+   */
+  syncTag: string | null;
   dismissed?: boolean; // Track if dismissed during popup
 }
 
@@ -33,16 +44,37 @@ class NotificationService {
     });
   }
 
-  private handleNewNotification(id: number): void {
-    const n = this.notifd.get_notification(id);
-    if (!n) return;
+  /**
+   * Read the freedesktop `x-canonical-private-synchronous` hint. Returns the
+   * tag string, or null if unset / wrong type. AstalNotifd exposes hints as
+   * raw GVariant — the spec doesn't strictly require type `s`, so guard with
+   * a type check before extracting the string payload.
+   */
+  private readSyncTag(n: Notifd.Notification): string | null {
+    let hint: ReturnType<Notifd.Notification["get_hint"]> = null;
+    try {
+      hint = n.get_hint("x-canonical-private-synchronous");
+    } catch {
+      return null;
+    }
+    if (!hint) return null;
+    try {
+      // Variant type "s" — string. Some senders use "(ss)" tuples; ignore.
+      if (hint.get_type_string() !== "s") return null;
+      const [value] = hint.get_string();
+      return value || null;
+    } catch {
+      return null;
+    }
+  }
 
+  private buildNotificationData(n: Notifd.Notification): NotificationData {
     // The image property contains custom notification images (image-path hint)
     // The app_icon can also contain a custom icon path (via -i flag in notify-send)
     const customImage = n.image || null;
     const appIconOrPath = n.app_icon || n.desktop_entry || null;
 
-    const notifData: NotificationData = {
+    return {
       id: n.id,
       appName: n.app_name || "Unknown",
       appIcon: appIconOrPath,
@@ -51,7 +83,23 @@ class NotificationService {
       body: n.body || "",
       time: n.time,
       urgency: n.urgency,
+      transient: n.transient === true,
+      syncTag: this.readSyncTag(n),
     };
+  }
+
+  private handleNewNotification(id: number): void {
+    const n = this.notifd.get_notification(id);
+    if (!n) return;
+
+    const notifData = this.buildNotificationData(n);
+
+    // Notifications marked transient or carrying a synchronous tag must never
+    // appear in persistent history. Mark them dismissed-from-history up front
+    // so getNotifications() and any later subscriber rebuilds filter them out.
+    if (notifData.transient || notifData.syncTag !== null) {
+      this.dismissedIds.add(notifData.id);
+    }
 
     // Notify popup listeners
     for (const listener of this.popupListeners) {
@@ -82,25 +130,24 @@ class NotificationService {
   }
 
   getNotifications(): NotificationData[] {
-    // Only return notifications that weren't dismissed during popup
+    // Only return notifications that weren't dismissed during popup and that
+    // are eligible for persistent history (transient + synchronous-tagged
+    // notifications are popup-only per spec).
     return this.notifd
       .get_notifications()
       .filter((n) => !this.dismissedIds.has(n.id))
-      .map((n) => {
-        const customImage = n.image || null;
-        const appIconOrPath = n.app_icon || n.desktop_entry || null;
+      .map((n) => this.buildNotificationData(n))
+      .filter((n) => !n.transient && n.syncTag === null);
+  }
 
-        return {
-          id: n.id,
-          appName: n.app_name || "Unknown",
-          appIcon: appIconOrPath,
-          image: customImage,
-          summary: n.summary || "",
-          body: n.body || "",
-          time: n.time,
-          urgency: n.urgency,
-        };
-      });
+  /**
+   * Returns true if the notification with the given id still exists on the
+   * server, regardless of history-eligibility. Popup containers use this to
+   * detect external dismissal (e.g. dunstctl close-all) without confusing
+   * transient/synchronous popups for "dismissed".
+   */
+  hasLiveNotification(id: number): boolean {
+    return this.notifd.get_notification(id) !== null;
   }
 
   getNotificationsByApp(): Map<string, NotificationData[]> {

--- a/config/services/vpn.tsx
+++ b/config/services/vpn.tsx
@@ -1,6 +1,9 @@
 import GLib from "gi://GLib";
 
+import { createLogger } from "helpers/logger";
 import { runAsync, spawnDetached } from "helpers/subprocess";
+
+const log = createLogger("VpnService");
 
 /**
  * Centralised VPN status service.
@@ -87,7 +90,7 @@ async function pollOnce(): Promise<void> {
         try {
           cb(current);
         } catch (e) {
-          console.error("[VpnService] listener error:", e);
+          log.error("listener error:", e);
         }
       }
     }

--- a/config/services/vpn.tsx
+++ b/config/services/vpn.tsx
@@ -1,0 +1,160 @@
+import GLib from "gi://GLib";
+
+import { runAsync, spawnDetached } from "helpers/subprocess";
+
+/**
+ * Centralised VPN status service.
+ *
+ * AstalNetwork has no VPN abstraction, so we fall back to nmcli polling.
+ * Previously two widgets (`network.tsx` and `connectivity-toggles.tsx`)
+ * each polled `nmcli` independently every 3 s on the GTK main thread via
+ * `spawn_command_line_sync` — six fork+exec per 3 s window plus blocking
+ * UI hitches.
+ *
+ * This service:
+ *   - polls once per 3 s for *all* subscribers
+ *   - uses `Gio.Subprocess` async (no main-thread block)
+ *   - emits change events only when status actually changes
+ *   - centralises connect/disconnect command construction
+ *
+ * Polling cadence reschedules from "now" via SOURCE_REMOVE rather than
+ * SOURCE_CONTINUE to avoid GLib's catch-up cascade after system suspend.
+ *
+ * Long-term replacement: subscribe to `org.freedesktop.NetworkManager`
+ * `ActiveConnections` PropertyChanged on D-Bus and drop polling. Out of
+ * scope for the current audit pass. See AUDIT C-1.5 / C-1.6 / C-3.1.
+ */
+
+export interface VpnStatus {
+  active: boolean;
+  /** Connection name (or empty string when inactive). */
+  name: string;
+}
+
+const POLL_MS = 3000;
+
+let current: VpnStatus = { active: false, name: "" };
+const listeners = new Set<(status: VpnStatus) => void>();
+let pollerId: number | null = null;
+let inFlight = false;
+
+function statusEqual(a: VpnStatus, b: VpnStatus): boolean {
+  return a.active === b.active && a.name === b.name;
+}
+
+function parseActiveConnections(stdout: string): VpnStatus {
+  for (const line of stdout.split("\n")) {
+    if (!line) continue;
+    // `nmcli -t` output is colon-separated; embedded colons in NAME are
+    // backslash-escaped (`\:`). Split on the *last* unescaped colon to
+    // recover (NAME, TYPE) safely.
+    let idx = -1;
+    for (let i = line.length - 1; i >= 0; i--) {
+      if (line[i] === ":" && line[i - 1] !== "\\") {
+        idx = i;
+        break;
+      }
+    }
+    if (idx < 0) continue;
+    const type = line.slice(idx + 1);
+    if (type === "vpn" || type === "wireguard") {
+      const name = line.slice(0, idx).replace(/\\:/g, ":") || "VPN";
+      return { active: true, name };
+    }
+  }
+  return { active: false, name: "" };
+}
+
+async function pollOnce(): Promise<void> {
+  if (inFlight) return;
+  inFlight = true;
+  try {
+    const stdout = await runAsync([
+      "nmcli",
+      "-t",
+      "-f",
+      "NAME,TYPE",
+      "connection",
+      "show",
+      "--active",
+    ]);
+    const next: VpnStatus = stdout
+      ? parseActiveConnections(stdout)
+      : { active: false, name: "" };
+    if (!statusEqual(current, next)) {
+      current = next;
+      for (const cb of listeners) {
+        try {
+          cb(current);
+        } catch (e) {
+          console.error("[VpnService] listener error:", e);
+        }
+      }
+    }
+  } finally {
+    inFlight = false;
+  }
+}
+
+function schedulePoll(): void {
+  pollerId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, POLL_MS, () => {
+    pollerId = null;
+    pollOnce().finally(() => {
+      // Reschedule from *now* so post-suspend wakeups don't cascade.
+      if (listeners.size > 0) schedulePoll();
+    });
+    return GLib.SOURCE_REMOVE;
+  });
+}
+
+function ensurePoller(): void {
+  if (pollerId !== null) return;
+  // Kick an immediate fetch so subscribers don't wait 3 s for the first
+  // accurate reading; the regular cadence picks up afterwards.
+  pollOnce().finally(() => {
+    if (listeners.size > 0) schedulePoll();
+  });
+}
+
+function stopPoller(): void {
+  if (pollerId !== null) {
+    GLib.source_remove(pollerId);
+    pollerId = null;
+  }
+}
+
+/**
+ * Subscribe to VPN status changes. The callback fires immediately with
+ * the most-recent known status (potentially `{active:false, name:""}`
+ * before the first poll completes), and again whenever the status
+ * changes. Returns an unsubscribe function.
+ */
+export function subscribeVpn(cb: (status: VpnStatus) => void): () => void {
+  listeners.add(cb);
+  cb(current);
+  ensurePoller();
+  return () => {
+    listeners.delete(cb);
+    if (listeners.size === 0) stopPoller();
+  };
+}
+
+/** Most recent VPN status (cheap synchronous read). */
+export function getVpnStatus(): VpnStatus {
+  return current;
+}
+
+/**
+ * Toggle the first available VPN/Wireguard connection. Async fire-and-
+ * forget: the next poll cycle (or whichever subscriber notices first)
+ * will surface the resulting state change.
+ */
+export function toggleVpn(): void {
+  const action = current.active ? "down" : "up";
+  // Use a shell to compose `nmcli ... | head -n1` because we need a
+  // single connection name. Quoted to handle names with spaces.
+  const sh = `nmcli connection ${action} "$(nmcli -t -f NAME,TYPE connection ${
+    current.active ? "show --active" : ""
+  } | awk -F: '$2=="vpn" || $2=="wireguard"{print $1; exit}')"`;
+  spawnDetached(["sh", "-c", sh]);
+}

--- a/config/services/window-manager.tsx
+++ b/config/services/window-manager.tsx
@@ -9,19 +9,33 @@ class WindowManager {
   private currentlyVisible: string | null = null;
   private isUpdating = false; // Prevent recursive updates
   private deactivateCallbacks: Map<string, () => void> = new Map();
+  // Owner widget for each managed window. Used by the bar-level click gate to
+  // distinguish "click on the pill that owns the open panel" (let pill toggle
+  // close it) from "click somewhere else in the bar" (force-dismiss).
+  private owners: Map<string, Gtk.Widget> = new Map();
 
   /**
-   * Register a window to be managed
+   * Register a window to be managed.
+   *
+   * @param owner Optional widget that "owns" this window (e.g. the pill button
+   *   that opens it). When set, `isOwnerOfVisible` can detect whether a click
+   *   target is inside that owner's subtree, so the bar-level dismiss gate can
+   *   skip dismissal and let the owner's own toggle handler run.
    */
   public register(
     name: string,
     window: Gtk.Window,
     onDeactivate?: () => void,
+    owner?: Gtk.Widget,
   ): void {
     this.windows.set(name, window);
 
     if (onDeactivate) {
       this.deactivateCallbacks.set(name, onDeactivate);
+    }
+
+    if (owner) {
+      this.owners.set(name, owner);
     }
 
     // Connect to visibility changes to track state
@@ -42,6 +56,7 @@ class WindowManager {
   public unregister(name: string): void {
     this.windows.delete(name);
     this.deactivateCallbacks.delete(name);
+    this.owners.delete(name);
     if (this.currentlyVisible === name) {
       this.currentlyVisible = null;
     }
@@ -165,6 +180,40 @@ class WindowManager {
    */
   public getCurrentlyVisible(): string | null {
     return this.currentlyVisible;
+  }
+
+  /**
+   * Returns true if `widget` is the registered owner of the currently-visible
+   * window, or a descendant of it. Walks the parent chain via `get_parent()`.
+   * Used by the bar-level click gate to skip dismissal when the click target
+   * belongs to the pill that opened the open panel.
+   */
+  public isOwnerOfVisible(widget: Gtk.Widget | null): boolean {
+    if (!widget || !this.currentlyVisible) return false;
+    const owner = this.owners.get(this.currentlyVisible);
+    if (!owner) return false;
+
+    let node: Gtk.Widget | null = widget;
+    while (node) {
+      if (node === owner) return true;
+      node = node.get_parent();
+    }
+    return false;
+  }
+
+  /**
+   * Set the owner widget for an already-registered window. Useful when the
+   * window is registered in one place (e.g. sidebar/panel.tsx) but the owner
+   * widget (e.g. the state-pill button) is created elsewhere and only
+   * knowable later. Idempotent; overwrites any prior owner.
+   */
+  public setOwner(name: string, owner: Gtk.Widget): void {
+    if (!this.windows.has(name)) {
+      // Window not registered yet (or already unregistered); silently no-op.
+      // Caller is expected to call this after the window is registered.
+      return;
+    }
+    this.owners.set(name, owner);
   }
 
   /**

--- a/config/services/window-manager.tsx
+++ b/config/services/window-manager.tsx
@@ -3,6 +3,9 @@
 // Ensures only one popup window is visible at a time
 
 import type Gtk from "gi://Gtk?version=4.0";
+import { createLogger } from "helpers/logger";
+
+const log = createLogger("WindowManager");
 
 class WindowManager {
   private windows: Map<string, Gtk.Window> = new Map();
@@ -68,7 +71,7 @@ class WindowManager {
   public show(name: string): void {
     const window = this.windows.get(name);
     if (!window) {
-      console.warn(`Window ${name} not registered with WindowManager`);
+      log.warn(`Window ${name} not registered`);
       return;
     }
 
@@ -156,7 +159,7 @@ class WindowManager {
   public toggle(name: string): void {
     const window = this.windows.get(name);
     if (!window) {
-      console.warn(`Window ${name} not registered with WindowManager`);
+      log.warn(`Window ${name} not registered`);
       return;
     }
 

--- a/config/sidebar/connectivity-toggles.tsx
+++ b/config/sidebar/connectivity-toggles.tsx
@@ -1,60 +1,11 @@
 import Bluetooth from "gi://AstalBluetooth";
 import Network from "gi://AstalNetwork";
-import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
+
+import { subscribeVpn, toggleVpn, type VpnStatus } from "services/vpn";
 
 const bluetooth = Bluetooth.get_default();
 const network = Network.get_default();
-
-// VPN detection helper
-function checkVpnStatus(): { active: boolean; name: string } {
-  try {
-    const [success, stdout] = GLib.spawn_command_line_sync(
-      "nmcli -t -f NAME,TYPE connection show --active",
-    );
-
-    if (!success || !stdout) {
-      return { active: false, name: "" };
-    }
-
-    const decoder = new TextDecoder();
-    const output = decoder.decode(stdout);
-    const lines = output.split("\n");
-
-    for (const line of lines) {
-      const [name, type] = line.split(":");
-      if (type === "vpn") {
-        return { active: true, name: name || "VPN" };
-      }
-    }
-
-    return { active: false, name: "" };
-  } catch (_e) {
-    return { active: false, name: "" };
-  }
-}
-
-function toggleVpn(currentlyActive: boolean): void {
-  if (currentlyActive) {
-    // Disconnect active VPN
-    try {
-      GLib.spawn_command_line_async(
-        "nmcli connection down id $(nmcli -t -f NAME,TYPE connection show --active | grep ':vpn$' | cut -d: -f1 | head -n1)",
-      );
-    } catch (e) {
-      console.error("Failed to disconnect VPN:", e);
-    }
-  } else {
-    // Try to connect to first available VPN
-    try {
-      GLib.spawn_command_line_async(
-        "nmcli connection up $(nmcli -t -f NAME,TYPE connection | grep ':vpn$' | cut -d: -f1 | head -n1)",
-      );
-    } catch (e) {
-      console.error("Failed to connect VPN:", e);
-    }
-  }
-}
 
 export function ConnectivityToggles(): Gtk.Box {
   const container = new Gtk.Box({
@@ -171,8 +122,7 @@ export function ConnectivityToggles(): Gtk.Box {
   vpnBtn.set_child(vpnBox);
 
   vpnBtn.connect("clicked", () => {
-    const vpnStatus = checkVpnStatus();
-    toggleVpn(vpnStatus.active);
+    toggleVpn();
   });
 
   connectivityRow.append(vpnBtn);
@@ -255,9 +205,10 @@ export function ConnectivityToggles(): Gtk.Box {
     }
   }
 
-  function updateVpn(): void {
-    const vpnStatus = checkVpnStatus();
+  // Track latest VPN status fed by the centralised service.
+  let vpnStatus: VpnStatus = { active: false, name: "" };
 
+  function updateVpn(): void {
     if (vpnStatus.active) {
       vpnBtn.add_css_class("active");
       vpnIcon.label = "󰖂"; // VPN connected
@@ -299,24 +250,13 @@ export function ConnectivityToggles(): Gtk.Box {
 
   const wiredHandler = network.wired?.connect("notify::state", updateEthernet);
 
-  // VPN monitoring via polling (since AstalNetwork doesn't expose VPN).
-  // Uses self-scheduling (SOURCE_REMOVE + manual reschedule) rather than
-  // return true to avoid the GLib "catch-up cascade" after system sleep:
-  // a repeating timer reschedules from its *last* fire time, so after a long
-  // sleep GLib would rapid-fire many callbacks before the event loop can handle
-  // any input. With SOURCE_REMOVE we always reschedule from now.
-  let vpnPollId: number | null = null;
-
-  const scheduleVpnPoll = () => {
-    vpnPollId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 3000, () => {
-      vpnPollId = null;
-      updateVpn();
-      scheduleVpnPoll();
-      return GLib.SOURCE_REMOVE;
-    });
-  };
-
-  scheduleVpnPoll();
+  // VPN status fed by the shared service (single 3 s nmcli poll for all
+  // subscribers; previously connectivity-toggles + network-pill ran two
+  // independent polls). See AUDIT C-3.1.
+  const unsubscribeVpn = subscribeVpn((status) => {
+    vpnStatus = status;
+    updateVpn();
+  });
 
   // Cleanup
   (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
@@ -338,10 +278,7 @@ export function ConnectivityToggles(): Gtk.Box {
     if (wiredHandler && network.wired) {
       network.wired.disconnect(wiredHandler);
     }
-    if (vpnPollId !== null) {
-      GLib.source_remove(vpnPollId);
-      vpnPollId = null;
-    }
+    unsubscribeVpn();
   };
 
   return container;

--- a/config/sidebar/connectivity-toggles.tsx
+++ b/config/sidebar/connectivity-toggles.tsx
@@ -2,6 +2,7 @@ import Bluetooth from "gi://AstalBluetooth";
 import Network from "gi://AstalNetwork";
 import Gtk from "gi://Gtk?version=4.0";
 
+import { registerCleanup } from "helpers/cleanup";
 import { subscribeVpn, toggleVpn, type VpnStatus } from "services/vpn";
 
 const bluetooth = Bluetooth.get_default();
@@ -259,7 +260,7 @@ export function ConnectivityToggles(): Gtk.Box {
   });
 
   // Cleanup
-  (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  registerCleanup(container, () => {
     if (btAdapterHandler && bluetooth.adapter) {
       bluetooth.adapter.disconnect(btAdapterHandler);
     }
@@ -279,7 +280,7 @@ export function ConnectivityToggles(): Gtk.Box {
       network.wired.disconnect(wiredHandler);
     }
     unsubscribeVpn();
-  };
+  });
 
   return container;
 }

--- a/config/sidebar/connectivity-toggles.tsx
+++ b/config/sidebar/connectivity-toggles.tsx
@@ -44,7 +44,9 @@ export function ConnectivityToggles(): Gtk.Box {
   bluetoothBtn.set_child(bluetoothBox);
 
   bluetoothBtn.connect("clicked", () => {
-    bluetooth.adapter.powered = !bluetooth.adapter.powered;
+    if (bluetooth.adapter) {
+      bluetooth.adapter.powered = !bluetooth.adapter.powered;
+    }
   });
 
   connectivityRow.append(bluetoothBtn);

--- a/config/sidebar/media-player.tsx
+++ b/config/sidebar/media-player.tsx
@@ -18,12 +18,39 @@ function formatTime(seconds: number): string {
   return `${mins}:${secs.toString().padStart(2, "0")}`;
 }
 
-function PlayerWidget(player: Mpris.Player): Gtk.Box {
+// Reject obviously-bogus track lengths.
+//
+// Some players (notably Firefox, web-based clients) advertise
+// `mpris:length = INT64_MAX` as a "length unknown" sentinel before they have
+// real metadata. After /1_000_000 that's ~9.22e12 seconds (~292 thousand
+// years) which is finite but useless: it briefly creates a slider that runs
+// for the heat-death of the universe. Anything over 24h is the sentinel.
+const MAX_REASONABLE_TRACK_SECONDS = 24 * 3600;
+function isUsableLength(length: number): boolean {
+  return (
+    Number.isFinite(length) &&
+    length > 0 &&
+    length < MAX_REASONABLE_TRACK_SECONDS
+  );
+}
+
+interface PlayerWidgetBox extends Gtk.Box {
+  _rebindTo?: (newPlayer: Mpris.Player) => void;
+  _currentPlayer?: Mpris.Player;
+  _cleanup?: () => void;
+}
+
+function PlayerWidget(initialPlayer: Mpris.Player): PlayerWidgetBox {
+  // Mutable holder so all closures resolve the *current* player at call time.
+  // This lets us rebind to a new player (e.g. Spotify -> Firefox) without
+  // tearing down and rebuilding all the widgets.
+  let currentPlayer: Mpris.Player = initialPlayer;
+
   const container = new Gtk.Box({
     orientation: Gtk.Orientation.VERTICAL,
     spacing: 12,
     css_classes: ["media-player"],
-  });
+  }) as PlayerWidgetBox;
 
   // Artwork and metadata row
   const topRow = new Gtk.Box({
@@ -109,9 +136,9 @@ function PlayerWidget(player: Mpris.Player): Gtk.Box {
   dragController.connect("drag-end", () => {
     isManuallyDragging = false;
     const value = positionScale.get_value();
-    const length = player.length;
+    const length = currentPlayer.length;
     if (length > 0) {
-      player.set_position(value);
+      currentPlayer.set_position(value);
     }
   });
   positionScale.add_controller(dragController);
@@ -173,8 +200,8 @@ function PlayerWidget(player: Mpris.Player): Gtk.Box {
   const prevIcon = new Gtk.Label({ label: "󰒮" });
   prevBtn.set_child(prevIcon);
   prevBtn.connect("clicked", () => {
-    if (player.can_go_previous) {
-      player.previous();
+    if (currentPlayer.can_go_previous) {
+      currentPlayer.previous();
     }
   });
   attachTooltip(prevBtn, {
@@ -190,8 +217,8 @@ function PlayerWidget(player: Mpris.Player): Gtk.Box {
   const playPauseIcon = new Gtk.Label({ label: "󰐊" });
   playPauseBtn.set_child(playPauseIcon);
   playPauseBtn.connect("clicked", () => {
-    if (player.can_pause) {
-      player.play_pause();
+    if (currentPlayer.can_pause) {
+      currentPlayer.play_pause();
     }
   });
   attachTooltip(playPauseBtn, {
@@ -207,8 +234,8 @@ function PlayerWidget(player: Mpris.Player): Gtk.Box {
   const nextIcon = new Gtk.Label({ label: "󰒭" });
   nextBtn.set_child(nextIcon);
   nextBtn.connect("clicked", () => {
-    if (player.can_go_next) {
-      player.next();
+    if (currentPlayer.can_go_next) {
+      currentPlayer.next();
     }
   });
   attachTooltip(nextBtn, {
@@ -235,6 +262,7 @@ function PlayerWidget(player: Mpris.Player): Gtk.Box {
 
   // Update function
   function updateMetadata(): void {
+    const player = currentPlayer;
     const title = player.title || "Unknown Title";
     const artist = player.artist || "";
     const album = player.album || "";
@@ -271,6 +299,7 @@ function PlayerWidget(player: Mpris.Player): Gtk.Box {
   }
 
   function updatePosition(): void {
+    const player = currentPlayer;
     // Get position - this seems to be working correctly
     const position = player.position ?? 0;
 
@@ -289,20 +318,57 @@ function PlayerWidget(player: Mpris.Player): Gtk.Box {
         null,
       ) as {
         get_int64?: () => number;
+        print?: (type_annotate: boolean) => string;
       } | null;
       if (lengthVariant && typeof lengthVariant.get_int64 === "function") {
-        // Length is in microseconds, convert to seconds
-        length = lengthVariant.get_int64() / 1000000;
+        // Some players (Firefox, web clients) publish mpris:length = INT64_MAX
+        // as a "length unknown" sentinel. Calling get_int64() on that would
+        // trigger a GJS precision warning *before* we ever see the value, so
+        // sniff the raw printed representation first and only convert if the
+        // magnitude is reasonable.
+        let lengthMicros: number | null = null;
+        if (typeof lengthVariant.print === "function") {
+          const printed = lengthVariant.print(false);
+          // For 'x' (int64) variants the printed form is just the digits,
+          // possibly with a leading '-'. Parse via BigInt to avoid any JS
+          // Number-precision involvement until we know it's safe.
+          try {
+            const big = BigInt(printed);
+            // 24h in microseconds = 86_400 * 1_000_000 = 8.64e10, well within
+            // Number-safe range (2^53 ≈ 9e15). Anything beyond a day is the
+            // sentinel.
+            const maxMicros = BigInt(MAX_REASONABLE_TRACK_SECONDS) * 1_000_000n;
+            if (big > 0n && big < maxMicros) {
+              lengthMicros = Number(big);
+            }
+          } catch (_e) {
+            // Not parseable as a plain integer; fall through to get_int64.
+            lengthMicros = null;
+          }
+        }
+        // If print() wasn't available (unlikely) and we have a small variant
+        // anyway, fall back to get_int64. We only reach this when print() is
+        // missing, since a sentinel value above would have set
+        // lengthMicros = null and we'd skip the conversion entirely.
+        if (
+          lengthMicros === null &&
+          typeof lengthVariant.print !== "function"
+        ) {
+          lengthMicros = lengthVariant.get_int64();
+        }
+        if (lengthMicros !== null) {
+          length = lengthMicros / 1_000_000;
+        }
       }
     }
 
     // Fallback: try player.length (some players like Firefox don't provide metadata)
-    if (length <= 0 || !Number.isFinite(length)) {
+    if (!isUsableLength(length)) {
       length = player.length ?? 0;
     }
 
     // If we still don't have a valid length, hide the slider
-    if (length <= 0 || !Number.isFinite(length)) {
+    if (!isUsableLength(length)) {
       positionBox.visible = false;
       return;
     }
@@ -317,6 +383,7 @@ function PlayerWidget(player: Mpris.Player): Gtk.Box {
   }
 
   function updateControls(): void {
+    const player = currentPlayer;
     // Play/Pause
     if (player.playback_status === Mpris.PlaybackStatus.PLAYING) {
       playPauseIcon.label = "󰏤"; // Pause
@@ -376,20 +443,41 @@ function PlayerWidget(player: Mpris.Player): Gtk.Box {
   // Initial update
   update();
 
-  // Connect to player signals
-  const metadataHandler = player.connect("notify::title", update);
-  const metadataChangeHandler = player.connect("notify::metadata", () => {
-    update();
-    updatePosition();
-  });
-  const lengthHandler = player.connect("notify::length", updatePosition);
-  const positionHandler = player.connect("notify::position", updatePosition);
-  const statusHandler = player.connect(
-    "notify::playback-status",
-    updateControls,
-  );
-  const shuffleHandler = player.connect("notify::shuffle", updateControls);
-  const loopHandler = player.connect("notify::loop-status", updateControls);
+  // Connect to player signals.
+  // Tracked as [player, handlerId] pairs so we can disconnect on rebind/cleanup
+  // even after `currentPlayer` has been swapped.
+  let playerHandlers: Array<[Mpris.Player, number]> = [];
+
+  const bindPlayerSignals = (p: Mpris.Player): void => {
+    playerHandlers = [
+      [p, p.connect("notify::title", update)],
+      [
+        p,
+        p.connect("notify::metadata", () => {
+          update();
+          updatePosition();
+        }),
+      ],
+      [p, p.connect("notify::length", updatePosition)],
+      [p, p.connect("notify::position", updatePosition)],
+      [p, p.connect("notify::playback-status", updateControls)],
+      [p, p.connect("notify::shuffle", updateControls)],
+      [p, p.connect("notify::loop-status", updateControls)],
+    ];
+  };
+
+  const unbindPlayerSignals = (): void => {
+    for (const [p, handlerId] of playerHandlers) {
+      try {
+        p.disconnect(handlerId);
+      } catch (_e) {
+        // Player may already be gone; ignore.
+      }
+    }
+    playerHandlers = [];
+  };
+
+  bindPlayerSignals(currentPlayer);
 
   // Position polling (since position updates might not trigger notify).
   // Uses self-scheduling (SOURCE_REMOVE + manual reschedule) rather than
@@ -402,7 +490,7 @@ function PlayerWidget(player: Mpris.Player): Gtk.Box {
   const schedulePositionPoll = () => {
     positionPollId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
       positionPollId = null;
-      if (player.playback_status === Mpris.PlaybackStatus.PLAYING) {
+      if (currentPlayer.playback_status === Mpris.PlaybackStatus.PLAYING) {
         updatePosition();
       }
       schedulePositionPoll();
@@ -412,15 +500,22 @@ function PlayerWidget(player: Mpris.Player): Gtk.Box {
 
   schedulePositionPoll();
 
+  // Expose current player so the parent can detect identity changes.
+  container._currentPlayer = currentPlayer;
+
+  // Swap to a new player without rebuilding any widgets.
+  container._rebindTo = (newPlayer: Mpris.Player): void => {
+    if (newPlayer === currentPlayer) return;
+    unbindPlayerSignals();
+    currentPlayer = newPlayer;
+    container._currentPlayer = currentPlayer;
+    bindPlayerSignals(currentPlayer);
+    update();
+  };
+
   // Cleanup
-  (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
-    player.disconnect(metadataHandler);
-    player.disconnect(metadataChangeHandler);
-    player.disconnect(lengthHandler);
-    player.disconnect(positionHandler);
-    player.disconnect(statusHandler);
-    player.disconnect(shuffleHandler);
-    player.disconnect(loopHandler);
+  container._cleanup = () => {
+    unbindPlayerSignals();
     if (positionPollId !== null) {
       GLib.source_remove(positionPollId);
       positionPollId = null;
@@ -444,31 +539,51 @@ export function MediaPlayer(): Gtk.Box {
   });
   container.append(playerContainer);
 
-  function update(): void {
-    // Clear existing
-    let child = playerContainer.get_first_child();
-    while (child) {
-      const next = child.get_next_sibling();
-      (child as Gtk.Widget & { _cleanup?: () => void })?._cleanup?.();
-      playerContainer.remove(child);
-      child = next;
-    }
-
+  function pickActivePlayer(): Mpris.Player | null {
     const players = mpris.get_players();
+    if (players.length === 0) return null;
+    return (
+      players.find((p) => p.playback_status === Mpris.PlaybackStatus.PLAYING) ||
+      players[0]
+    );
+  }
 
-    if (players.length === 0) {
-      // Hide the entire widget when no media is playing
+  function update(): void {
+    const activePlayer = pickActivePlayer();
+
+    if (activePlayer === null) {
+      // Tear down any existing widget and hide.
+      let child = playerContainer.get_first_child();
+      while (child) {
+        const next = child.get_next_sibling();
+        (child as PlayerWidgetBox)._cleanup?.();
+        playerContainer.remove(child);
+        child = next;
+      }
       container.visible = false;
-    } else {
-      // Show the first active player (or just the first one)
-      const activePlayer =
-        players.find(
-          (p) => p.playback_status === Mpris.PlaybackStatus.PLAYING,
-        ) || players[0];
-
-      playerContainer.append(PlayerWidget(activePlayer));
-      container.visible = true;
+      return;
     }
+
+    const existing =
+      playerContainer.get_first_child() as PlayerWidgetBox | null;
+    if (existing) {
+      if (existing._currentPlayer === activePlayer) {
+        // Same player, nothing to do.
+        return;
+      }
+      // Different player: rebind in place to preserve widgets/animations.
+      if (existing._rebindTo) {
+        existing._rebindTo(activePlayer);
+        container.visible = true;
+        return;
+      }
+      // Fallback: tear down and rebuild (shouldn't happen).
+      existing._cleanup?.();
+      playerContainer.remove(existing);
+    }
+
+    playerContainer.append(PlayerWidget(activePlayer));
+    container.visible = true;
   }
 
   // Initial update
@@ -478,23 +593,17 @@ export function MediaPlayer(): Gtk.Box {
   const addHandler = mpris.connect("player-added", update);
   const removeHandler = mpris.connect("player-closed", update);
 
-  // Poll for active player changes (when switching between existing players).
+  // Poll for active player changes (when switching between existing players,
+  // since AstalMpris doesn't emit a signal for that).
+  // `update()` is now cheap when the active player is unchanged: it short-
+  // circuits on identity match and only rebinds (no widget rebuild) on swap.
   // Self-scheduling to avoid the GLib "catch-up cascade" after system sleep.
   let playerSwitchPollId: number | null = null;
 
   const schedulePlayerSwitchPoll = () => {
     playerSwitchPollId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2000, () => {
       playerSwitchPollId = null;
-      const players = mpris.get_players();
-      if (players.length > 1) {
-        // Multiple players - check if active one changed
-        const activePlayer = players.find(
-          (p) => p.playback_status === Mpris.PlaybackStatus.PLAYING,
-        );
-        if (activePlayer) {
-          update(); // Rebuild widget for new active player
-        }
-      }
+      update();
       schedulePlayerSwitchPoll();
       return GLib.SOURCE_REMOVE;
     });
@@ -515,7 +624,7 @@ export function MediaPlayer(): Gtk.Box {
     let child = playerContainer.get_first_child();
     while (child) {
       const next = child.get_next_sibling();
-      (child as Gtk.Widget & { _cleanup?: () => void })?._cleanup?.();
+      (child as PlayerWidgetBox)._cleanup?.();
       child = next;
     }
   };

--- a/config/sidebar/media-player.tsx
+++ b/config/sidebar/media-player.tsx
@@ -1,6 +1,7 @@
 import Mpris from "gi://AstalMpris";
 import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
+import { registerCleanup } from "helpers/cleanup";
 import { attachTooltip } from "helpers/tooltip";
 
 const mpris = Mpris.get_default();
@@ -514,13 +515,13 @@ function PlayerWidget(initialPlayer: Mpris.Player): PlayerWidgetBox {
   };
 
   // Cleanup
-  container._cleanup = () => {
+  registerCleanup(container, () => {
     unbindPlayerSignals();
     if (positionPollId !== null) {
       GLib.source_remove(positionPollId);
       positionPollId = null;
     }
-  };
+  });
 
   return container;
 }
@@ -611,23 +612,19 @@ export function MediaPlayer(): Gtk.Box {
 
   schedulePlayerSwitchPoll();
 
-  // Cleanup
-  (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  // Cleanup. Child PlayerWidget boxes are also _cleanup-bound (via
+  // registerCleanup), so destroying them via remove()/unparent() is enough
+  // — the destroy signal fires their own cleanups. We still walk children
+  // explicitly here because they may have been removed from this container
+  // before destroy fires (rebind path).
+  registerCleanup(container, () => {
     mpris.disconnect(addHandler);
     mpris.disconnect(removeHandler);
     if (playerSwitchPollId !== null) {
       GLib.source_remove(playerSwitchPollId);
       playerSwitchPollId = null;
     }
-
-    // Cleanup player widgets
-    let child = playerContainer.get_first_child();
-    while (child) {
-      const next = child.get_next_sibling();
-      (child as PlayerWidgetBox)._cleanup?.();
-      child = next;
-    }
-  };
+  });
 
   return container;
 }

--- a/config/sidebar/media-player.tsx
+++ b/config/sidebar/media-player.tsx
@@ -305,11 +305,7 @@ function PlayerWidget(initialPlayer: Mpris.Player): PlayerWidgetBox {
     const position = player.position ?? 0;
 
     // Try to get the actual track length from the GLib.Variant metadata
-    const metadataVariant = (
-      player as unknown as {
-        metadata?: { lookup_value?: (key: string, type: null) => unknown };
-      }
-    ).metadata;
+    const metadataVariant = player.metadata;
     let length = 0;
 
     if (metadataVariant && typeof metadataVariant.lookup_value === "function") {
@@ -397,23 +393,23 @@ function PlayerWidget(initialPlayer: Mpris.Player): PlayerWidgetBox {
     prevBtn.sensitive = player.can_go_previous;
     nextBtn.sensitive = player.can_go_next;
 
-    // Shuffle - display only
-    const shuffleStatus = (player as unknown as { shuffle?: boolean }).shuffle;
-    if (shuffleStatus !== undefined && shuffleStatus !== null) {
-      if (shuffleStatus) {
+    // Shuffle - display only. shuffle_status is a Shuffle enum:
+    // UNSUPPORTED (hide button), ON (active), OFF (inactive).
+    const shuffleStatus = player.shuffle_status;
+    if (shuffleStatus === Mpris.Shuffle.UNSUPPORTED) {
+      shuffleBtn.visible = false;
+    } else {
+      if (shuffleStatus === Mpris.Shuffle.ON) {
         shuffleBtn.add_css_class("active");
       } else {
         shuffleBtn.remove_css_class("active");
       }
       shuffleBtn.visible = true;
-    } else {
-      shuffleBtn.visible = false;
     }
 
     // Loop - display only
-    const loopStatus = (player as unknown as { loop_status?: number })
-      .loop_status;
-    if (loopStatus !== undefined && loopStatus !== null) {
+    const loopStatus = player.loop_status;
+    if (loopStatus !== Mpris.Loop.UNSUPPORTED) {
       loopBtn.remove_css_class("active");
       loopBtn.remove_css_class("loop-track");
       loopBtn.remove_css_class("loop-playlist");

--- a/config/sidebar/notification-list.tsx
+++ b/config/sidebar/notification-list.tsx
@@ -13,7 +13,7 @@ function formatTime(timestamp: number): string {
 
   if (!notifTime) return "";
 
-  const diff = now.difference(notifTime) / 1_000_000; // Convert to seconds
+  const diff = Number(now.difference(notifTime)) / 1_000_000; // Convert to seconds
 
   if (diff < 60) {
     return "Just now";
@@ -33,7 +33,7 @@ function formatTime(timestamp: number): string {
 function NotificationItem(
   notif: NotificationData,
   isGrouped: boolean,
-): Gtk.Box {
+): Gtk.Widget {
   const container = new Gtk.Box({
     orientation: Gtk.Orientation.VERTICAL,
     spacing: 0,
@@ -168,7 +168,7 @@ function NotificationItem(
     button.add_css_class("urgency-low");
   }
 
-  return button as unknown as Gtk.Box;
+  return button;
 }
 
 interface NotificationGroupProps {

--- a/config/sidebar/notification-list.tsx
+++ b/config/sidebar/notification-list.tsx
@@ -1,5 +1,6 @@
 import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
+import { registerCleanup } from "helpers/cleanup";
 import { resolveAppIcon, resolveNotificationIcon } from "helpers/icon-resolver";
 import {
   type NotificationData,
@@ -398,9 +399,9 @@ export function NotificationList(): Gtk.Box {
   const unsubscribe = notificationService.subscribe(update);
 
   // Cleanup
-  (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  registerCleanup(container, () => {
     unsubscribe();
-  };
+  });
 
   return container;
 }

--- a/config/sidebar/panel.tsx
+++ b/config/sidebar/panel.tsx
@@ -2,6 +2,7 @@ import Gtk from "gi://Gtk?version=4.0";
 import { Astal } from "ags/gtk4";
 import { setupBackdrop } from "helpers/backdrop";
 import { registerCleanup } from "helpers/cleanup";
+import { asWindow } from "helpers/jsx";
 import { notificationService } from "services/notifications";
 import { getWindowManager } from "services/window-manager";
 import { ConnectivityToggles } from "./connectivity-toggles";
@@ -196,7 +197,7 @@ export function SidebarWindow(monitorIndex: number): Gtk.Window {
   const windowManager = getWindowManager();
   const windowName = `sidebar-${monitorIndex}`;
 
-  const win = (
+  const win = asWindow(
     <window
       name={windowName}
       visible={false}
@@ -218,8 +219,8 @@ export function SidebarWindow(monitorIndex: number): Gtk.Window {
       keymode={Astal.Keymode.NONE}
     >
       <SidebarPanel />
-    </window>
-  ) as unknown as Gtk.Window;
+    </window>,
+  );
 
   // Create backdrop window for click-outside-to-close
   const _backdrop = setupBackdrop(win, () => {

--- a/config/sidebar/panel.tsx
+++ b/config/sidebar/panel.tsx
@@ -1,6 +1,7 @@
 import Gtk from "gi://Gtk?version=4.0";
 import { Astal } from "ags/gtk4";
 import { setupBackdrop } from "helpers/backdrop";
+import { registerCleanup } from "helpers/cleanup";
 import { notificationService } from "services/notifications";
 import { getWindowManager } from "services/window-manager";
 import { ConnectivityToggles } from "./connectivity-toggles";
@@ -181,17 +182,11 @@ export function SidebarPanel(): Gtk.Box {
     updateCount();
   });
 
-  // Cleanup
-  (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  // Cleanup. Children now auto-clean via the destroy signal, so we only
+  // need to drop the notification-service subscription here.
+  registerCleanup(container, () => {
     unsubscribe();
-    (mediaPlayer as Gtk.Widget & { _cleanup?: () => void })?._cleanup?.();
-    (
-      connectivityToggles as Gtk.Widget & { _cleanup?: () => void }
-    )?._cleanup?.();
-    (powerProfiles as Gtk.Widget & { _cleanup?: () => void })?._cleanup?.();
-    (sliders as Gtk.Widget & { _cleanup?: () => void })?._cleanup?.();
-    (notifList as Gtk.Widget & { _cleanup?: () => void })?._cleanup?.();
-  };
+  });
 
   return container;
 }

--- a/config/sidebar/panel.tsx
+++ b/config/sidebar/panel.tsx
@@ -211,7 +211,16 @@ export function SidebarWindow(monitorIndex: number): Gtk.Window {
       default_width={0}
       exclusivity={Astal.Exclusivity.NORMAL}
       layer={Astal.Layer.OVERLAY}
-      keymode={Astal.Keymode.ON_DEMAND}
+      // Keymode.NONE (not ON_DEMAND). With ON_DEMAND, the compositor
+      // transfers the implicit pointer grab to the sidebar surface
+      // when it maps. The bar then receives `pointer.leave` and
+      // subsequent clicks on the state-pill (or any other bar pill)
+      // are not delivered to the button widget until the pointer
+      // moves again, breaking "click pill to dismiss". With NONE,
+      // the bar keeps its pointer grab. Trade-off: ESC won't dismiss
+      // via the window's own key controller; if needed later, use a
+      // global key-snooper on the application root.
+      keymode={Astal.Keymode.NONE}
     >
       <SidebarPanel />
     </window>

--- a/config/sidebar/power-profiles.tsx
+++ b/config/sidebar/power-profiles.tsx
@@ -1,5 +1,6 @@
 import PowerProfiles from "gi://AstalPowerProfiles";
 import Gtk from "gi://Gtk?version=4.0";
+import { registerCleanup } from "helpers/cleanup";
 
 const powerProfiles = PowerProfiles.get_default();
 
@@ -95,9 +96,9 @@ export function PowerProfilesToggle(): Gtk.Box | null {
   );
 
   // Cleanup
-  (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  registerCleanup(container, () => {
     powerProfiles.disconnect(handler);
-  };
+  });
 
   return container;
 }

--- a/config/sidebar/sliders.tsx
+++ b/config/sidebar/sliders.tsx
@@ -2,7 +2,10 @@ import Wp from "gi://AstalWp";
 import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 
+import { createLogger } from "helpers/logger";
 import { runAsync } from "helpers/subprocess";
+
+const log = createLogger("Sliders");
 
 const audio = Wp.get_default();
 
@@ -262,7 +265,7 @@ function setBrightness(
         `ddcutil setvcp 10 ${percentage} --bus ${busNum} --sleep-multiplier 0.1 --noverify`,
       );
     } catch (e) {
-      console.error("Failed to set DDC brightness:", e);
+      log.error("Failed to set DDC brightness:", e);
     }
     return;
   }
@@ -280,7 +283,7 @@ function setBrightness(
       const brightnessFile = `${devicePath}/brightness`;
       GLib.file_set_contents(brightnessFile, `${Math.round(value)}\n`);
     } catch (writeError) {
-      console.error("Failed to set brightness:", writeError);
+      log.error("Failed to set brightness:", writeError);
     }
   }
 }

--- a/config/sidebar/sliders.tsx
+++ b/config/sidebar/sliders.tsx
@@ -1,47 +1,10 @@
 import Wp from "gi://AstalWp";
-import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 
+import { runAsync } from "helpers/subprocess";
+
 const audio = Wp.get_default();
-
-/**
- * Run a shell command without blocking the GTK main loop and resolve with
- * the captured stdout. We use Gio.Subprocess (the GLib-blessed async-IO
- * primitive) so the result lands on the main thread via the GLib MainContext
- * — no manual `idle_add` plumbing required.
- *
- * Errors and non-zero exits resolve to `null` rather than rejecting; callers
- * uniformly want "if it didn't work, fall through" semantics, and we'd
- * otherwise need a try/catch at every call site.
- */
-function runAsync(argv: string[]): Promise<string | null> {
-  return new Promise((resolve) => {
-    let proc: Gio.Subprocess;
-    try {
-      proc = Gio.Subprocess.new(
-        argv,
-        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE,
-      );
-    } catch {
-      resolve(null);
-      return;
-    }
-
-    proc.communicate_utf8_async(null, null, (_p, res) => {
-      try {
-        const [success, stdout] = proc.communicate_utf8_finish(res);
-        if (!success || !proc.get_successful()) {
-          resolve(null);
-          return;
-        }
-        resolve(stdout ?? null);
-      } catch {
-        resolve(null);
-      }
-    });
-  });
-}
 
 // Brightness control using /sys/class/backlight and /sys/class/leds
 interface BrightnessDevice {

--- a/config/sidebar/sliders.tsx
+++ b/config/sidebar/sliders.tsx
@@ -1,8 +1,47 @@
 import Wp from "gi://AstalWp";
+import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 
 const audio = Wp.get_default();
+
+/**
+ * Run a shell command without blocking the GTK main loop and resolve with
+ * the captured stdout. We use Gio.Subprocess (the GLib-blessed async-IO
+ * primitive) so the result lands on the main thread via the GLib MainContext
+ * — no manual `idle_add` plumbing required.
+ *
+ * Errors and non-zero exits resolve to `null` rather than rejecting; callers
+ * uniformly want "if it didn't work, fall through" semantics, and we'd
+ * otherwise need a try/catch at every call site.
+ */
+function runAsync(argv: string[]): Promise<string | null> {
+  return new Promise((resolve) => {
+    let proc: Gio.Subprocess;
+    try {
+      proc = Gio.Subprocess.new(
+        argv,
+        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE,
+      );
+    } catch {
+      resolve(null);
+      return;
+    }
+
+    proc.communicate_utf8_async(null, null, (_p, res) => {
+      try {
+        const [success, stdout] = proc.communicate_utf8_finish(res);
+        if (!success || !proc.get_successful()) {
+          resolve(null);
+          return;
+        }
+        resolve(stdout ?? null);
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+}
 
 // Brightness control using /sys/class/backlight and /sys/class/leds
 interface BrightnessDevice {
@@ -41,86 +80,97 @@ function getDeviceDisplayName(
   return name.charAt(0).toUpperCase() + name.slice(1);
 }
 
-// Cache for DDC monitor info to avoid slow detection on every call
+// Cache for DDC monitor info to avoid slow detection on every call.
+// Populated asynchronously; until detection finishes we treat it as empty
+// rather than blocking the GTK main loop on `ddcutil detect` (which can
+// take 1-3 seconds even with --sleep-multiplier 0.1).
 let ddcMonitorsCache: Array<{
   bus: string;
   name: string;
   max: number;
 }> | null = null;
+let ddcDetectionInFlight: Promise<void> | null = null;
+
+function parseDdcutilDetect(output: string): Array<{
+  bus: string;
+  name: string;
+  max: number;
+}> {
+  const monitors: Array<{ bus: string; name: string; max: number }> = [];
+  const lines = output.split("\n");
+
+  let currentDisplay: { displayNum: string; name: string } | null = null;
+
+  for (const line of lines) {
+    const displayMatch = line.match(/Display\s+(\d+)/);
+    if (displayMatch) {
+      currentDisplay = { displayNum: displayMatch[1], name: "" };
+      continue;
+    }
+
+    const nameMatch = line.match(/Monitor:\s+(.+)/);
+    if (nameMatch && currentDisplay) {
+      currentDisplay.name = nameMatch[1].trim();
+    }
+
+    const busMatch = line.match(/I2C bus:\s+\/dev\/i2c-(\d+)/);
+    if (busMatch && currentDisplay) {
+      monitors.push({
+        bus: busMatch[1],
+        name: currentDisplay.name || `Monitor ${currentDisplay.displayNum}`,
+        max: 100,
+      });
+      currentDisplay = null;
+    }
+  }
+
+  return monitors;
+}
+
+/**
+ * Kick off DDC monitor detection asynchronously. Idempotent: subsequent
+ * calls while the first is in flight share the same Promise; calls after
+ * completion are no-ops (the cache is already populated).
+ */
+function detectDDCMonitorsAsync(): Promise<void> {
+  if (ddcMonitorsCache !== null) return Promise.resolve();
+  if (ddcDetectionInFlight) return ddcDetectionInFlight;
+
+  ddcDetectionInFlight = runAsync([
+    "ddcutil",
+    "detect",
+    "--sleep-multiplier",
+    "0.1",
+  ]).then((stdout) => {
+    ddcMonitorsCache = stdout ? parseDdcutilDetect(stdout) : [];
+    ddcDetectionInFlight = null;
+  });
+
+  return ddcDetectionInFlight;
+}
 
 function getDDCMonitors(): BrightnessDevice[] {
-  // Return cached results or empty - don't block on detection
-  if (ddcMonitorsCache !== null) {
-    const devices: BrightnessDevice[] = [];
-    for (const monitor of ddcMonitorsCache) {
-      devices.push({
-        name: `ddcci-${monitor.bus}`,
-        displayName: monitor.name,
-        path: monitor.bus,
-        max: monitor.max,
-        current: 50, // Default to 50, will be updated by async call in widget
-        type: "ddcci",
-      });
-    }
-    return devices;
+  // Synchronous accessor: returns whatever's cached. If detection hasn't
+  // finished yet, we return [] — the user won't see DDC sliders this open,
+  // but the pre-warm at module-load means by the time the sidebar is first
+  // opened the cache is almost always populated. Worst case: re-open the
+  // sidebar once detection lands.
+  if (ddcMonitorsCache === null) {
+    detectDDCMonitorsAsync(); // fire-and-forget; populates cache
+    return [];
   }
 
-  // First time - detect monitors (blocking, but only happens once per session)
-  const monitors: Array<{ bus: string; name: string; max: number }> = [];
-
-  try {
-    const [success, stdout] = GLib.spawn_command_line_sync(
-      "ddcutil detect --sleep-multiplier 0.1",
-    );
-
-    if (success && stdout) {
-      const output = new TextDecoder().decode(stdout);
-      const lines = output.split("\n");
-
-      let currentDisplay: { displayNum: string; name: string } | null = null;
-
-      for (const line of lines) {
-        const displayMatch = line.match(/Display\s+(\d+)/);
-        if (displayMatch) {
-          currentDisplay = { displayNum: displayMatch[1], name: "" };
-          continue;
-        }
-
-        const nameMatch = line.match(/Monitor:\s+(.+)/);
-        if (nameMatch && currentDisplay) {
-          currentDisplay.name = nameMatch[1].trim();
-        }
-
-        const busMatch = line.match(/I2C bus:\s+\/dev\/i2c-(\d+)/);
-        if (busMatch && currentDisplay) {
-          monitors.push({
-            bus: busMatch[1],
-            name: currentDisplay.name || `Monitor ${currentDisplay.displayNum}`,
-            max: 100,
-          });
-          currentDisplay = null;
-        }
-      }
-    }
-  } catch (_e) {
-    // ddcutil not available or failed
-  }
-
-  ddcMonitorsCache = monitors;
   const devices: BrightnessDevice[] = [];
-
-  for (const monitor of monitors) {
-    // Start with cached max, brightness will be updated async
+  for (const monitor of ddcMonitorsCache) {
     devices.push({
       name: `ddcci-${monitor.bus}`,
       displayName: monitor.name,
       path: monitor.bus,
       max: monitor.max,
-      current: 50, // Default to 50, will be updated by async call in widget
+      current: 50, // updated by async getvcp in BrightnessSlider
       type: "ddcci",
     });
   }
-
   return devices;
 }
 
@@ -392,35 +442,33 @@ function BrightnessSlider(device: BrightnessDevice): Gtk.Box {
   });
   container.add_controller(scrollController);
 
-  // Initial brightness fetch for DDC monitors (async)
+  // Initial brightness fetch for DDC monitors. Truly async via
+  // Gio.Subprocess — the previous implementation fired
+  // spawn_command_line_async (whose stdout was discarded), waited 500ms,
+  // then ran spawn_command_line_sync of the same command, blocking the
+  // GTK loop on `ddcutil getvcp`. This both wasted the first invocation
+  // and froze the UI on the second.
   if (device.type === "ddcci") {
-    GLib.spawn_command_line_async(
-      `ddcutil getvcp 10 --bus ${device.path} --brief --sleep-multiplier 0.1`,
-    );
-    // Read result asynchronously
-    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
-      try {
-        const [success, stdout] = GLib.spawn_command_line_sync(
-          `ddcutil getvcp 10 --bus ${device.path} --brief --sleep-multiplier 0.1`,
-        );
-        if (success && stdout) {
-          const output = new TextDecoder().decode(stdout);
-          const match = output.match(/VCP\s+10\s+\w+\s+(\d+)\s+(\d+)/);
-          if (match) {
-            const current = parseInt(match[1], 10);
-            const max = parseInt(match[2], 10);
-            if (!Number.isNaN(current) && !Number.isNaN(max)) {
-              isChanging = true;
-              scale.set_range(0, max);
-              scale.set_value(current);
-              isChanging = false;
-            }
-          }
-        }
-      } catch (_e) {
-        // Failed to get initial brightness
-      }
-      return false; // Don't repeat
+    runAsync([
+      "ddcutil",
+      "getvcp",
+      "10",
+      "--bus",
+      device.path,
+      "--brief",
+      "--sleep-multiplier",
+      "0.1",
+    ]).then((output) => {
+      if (!output) return;
+      const match = output.match(/VCP\s+10\s+\w+\s+(\d+)\s+(\d+)/);
+      if (!match) return;
+      const current = parseInt(match[1], 10);
+      const max = parseInt(match[2], 10);
+      if (Number.isNaN(current) || Number.isNaN(max)) return;
+      isChanging = true;
+      scale.set_range(0, max);
+      scale.set_value(current);
+      isChanging = false;
     });
   }
 
@@ -676,12 +724,16 @@ export function Sliders(): Gtk.Box {
   return container;
 }
 
-// Pre-warm DDC monitor detection cache in background on module load
-// This prevents the first sidebar open from being slow
+// Pre-warm DDC monitor detection cache in the background on module load.
+// `detectDDCMonitorsAsync` uses Gio.Subprocess so the ddcutil invocation
+// runs off-thread; the GTK main loop stays responsive even if ddcutil
+// itself takes seconds. By the time the user opens the sidebar the cache
+// is almost always populated, and DDC sliders appear without the first
+// open ever blocking on i2c probes. The previous implementation called
+// the synchronous detector from a 100ms timeout — that runs on the main
+// thread, so the freeze just moved from "first sidebar open" to "first
+// 100ms after launch". This actually fixes it.
 GLib.timeout_add(GLib.PRIORITY_LOW, 100, () => {
-  if (ddcMonitorsCache === null) {
-    // Trigger detection in background
-    getDDCMonitors();
-  }
+  detectDDCMonitorsAsync();
   return false; // Don't repeat
 });

--- a/config/sidebar/sliders.tsx
+++ b/config/sidebar/sliders.tsx
@@ -2,6 +2,7 @@ import Wp from "gi://AstalWp";
 import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 
+import { registerCleanup } from "helpers/cleanup";
 import { createLogger } from "helpers/logger";
 import { runAsync } from "helpers/subprocess";
 
@@ -493,14 +494,14 @@ function BrightnessSlider(device: BrightnessDevice): Gtk.Box {
   }
 
   // Cleanup
-  (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  registerCleanup(container, () => {
     if (pollInterval !== null) {
       GLib.source_remove(pollInterval);
     }
     if (debounceTimeout !== null) {
       GLib.source_remove(debounceTimeout);
     }
-  };
+  });
 
   return container;
 }
@@ -637,10 +638,10 @@ function VolumeSlider(
   const muteHandler = endpoint.connect("notify::mute", updateDisplay);
 
   // Cleanup
-  (container as Gtk.Widget & { _cleanup?: () => void })._cleanup = () => {
+  registerCleanup(container, () => {
     endpoint.disconnect(volumeHandler);
     endpoint.disconnect(muteHandler);
-  };
+  });
 
   return container;
 }

--- a/config/sidebar/system-actions.tsx
+++ b/config/sidebar/system-actions.tsx
@@ -1,82 +1,34 @@
-import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 
-// Detect which compositor is running
-function detectCompositor(): "hyprland" | "niri" | "sway" | "other" {
-  const session = GLib.getenv("XDG_CURRENT_DESKTOP") || "";
-  const sessionLower = session.toLowerCase();
+import { spawnDetached } from "helpers/subprocess";
+import { getCompositorExitCommand } from "services/compositor-detect";
 
-  if (sessionLower.includes("hyprland")) {
-    return "hyprland";
-  }
-  if (sessionLower.includes("niri")) {
-    return "niri";
-  }
-  if (sessionLower.includes("sway")) {
-    return "sway";
-  }
-
-  // Try checking running processes
-  try {
-    const [, stdout] = GLib.spawn_command_line_sync("pgrep -x hyprland");
-    if (stdout && stdout.length > 0) {
-      return "hyprland";
-    }
-  } catch {
-    // ignore
-  }
-
-  try {
-    const [, stdout] = GLib.spawn_command_line_sync("pgrep -x niri");
-    if (stdout && stdout.length > 0) {
-      return "niri";
-    }
-  } catch {
-    // ignore
-  }
-
-  try {
-    const [, stdout] = GLib.spawn_command_line_sync("pgrep -x sway");
-    if (stdout && stdout.length > 0) {
-      return "sway";
-    }
-  } catch {
-    // ignore
-  }
-
-  return "other";
+function getLogoutCommand(): string[] {
+  return getCompositorExitCommand() ?? ["loginctl", "terminate-user", "$USER"];
 }
 
-function getCompositorExitCommand(): string | null {
-  const compositor = detectCompositor();
-
-  switch (compositor) {
-    case "hyprland":
-      return "setsid hyprshutdown";
-    case "niri":
-      return "niri msg action quit";
-    case "sway":
-      return "swaymsg exit";
-    default:
-      return null;
-  }
-}
-
-function getLogoutCommand(): string {
-  return getCompositorExitCommand() ?? "loginctl terminate-user $USER";
-}
-
-function withCompositorExit(systemCommand: string): string {
+function withCompositorExit(systemCommand: string[]): string[] {
   const exitCmd = getCompositorExitCommand();
-  return exitCmd ? `sh -c '${exitCmd} && ${systemCommand}'` : systemCommand;
+  if (!exitCmd) return systemCommand;
+  // Compose: run compositor exit, then the system command. Falling back
+  // to a shell here is unavoidable because we want sequencing.
+  const exitStr = exitCmd.map(shellQuote).join(" ");
+  const sysStr = systemCommand.map(shellQuote).join(" ");
+  return ["sh", "-c", `${exitStr} && ${sysStr}`];
 }
 
-function executeCommand(command: string): void {
-  try {
-    GLib.spawn_command_line_async(command);
-  } catch (e) {
-    console.error(`Failed to execute command: ${command}`, e);
-  }
+/**
+ * Quote a single argv token for a `sh -c` body. Only runs against
+ * trusted, hard-coded values (compositor exit + systemctl invocations),
+ * but encapsulating it keeps the call sites honest.
+ */
+function shellQuote(arg: string): string {
+  if (/^[a-zA-Z0-9_\-./=]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+function executeCommand(argv: string[]): void {
+  spawnDetached(argv);
 }
 
 export function SystemActions(): Gtk.Box {
@@ -140,7 +92,7 @@ export function SystemActions(): Gtk.Box {
   rebootBox.append(rebootLabel);
   rebootBtn.set_child(rebootBox);
   rebootBtn.connect("clicked", () => {
-    executeCommand(withCompositorExit("systemctl reboot"));
+    executeCommand(withCompositorExit(["systemctl", "reboot"]));
   });
   powerRow.append(rebootBtn);
 
@@ -165,7 +117,7 @@ export function SystemActions(): Gtk.Box {
   shutdownBox.append(shutdownLabel);
   shutdownBtn.set_child(shutdownBox);
   shutdownBtn.connect("clicked", () => {
-    executeCommand(withCompositorExit("systemctl poweroff"));
+    executeCommand(withCompositorExit(["systemctl", "poweroff"]));
   });
   powerRow.append(shutdownBtn);
 

--- a/config/sidebar/system-actions.tsx
+++ b/config/sidebar/system-actions.tsx
@@ -1,10 +1,19 @@
+import GLib from "gi://GLib?version=2.0";
 import Gtk from "gi://Gtk?version=4.0";
 
 import { spawnDetached } from "helpers/subprocess";
 import { getCompositorExitCommand } from "services/compositor-detect";
 
 function getLogoutCommand(): string[] {
-  return getCompositorExitCommand() ?? ["loginctl", "terminate-user", "$USER"];
+  // Resolve the current user in-process: Gio.Subprocess never invokes a
+  // shell when given an argv, so "$USER" would be passed literally.
+  return (
+    getCompositorExitCommand() ?? [
+      "loginctl",
+      "terminate-user",
+      GLib.get_user_name(),
+    ]
+  );
 }
 
 function withCompositorExit(systemCommand: string[]): string[] {

--- a/config/styles/components/_tray.scss
+++ b/config/styles/components/_tray.scss
@@ -32,8 +32,12 @@ popover.tray-menu {
   border: none;
   padding: 0;
   margin: 0;
-  margin-top: 32px;
-  margin-left: -32px;
+  // The popover is now anchored BOTTOM (see tray-item.tsx) and arrow is
+  // hidden, so the menu drops straight down from the tray button. No
+  // horizontal offset — GTK 4 will auto-flip if the menu would overflow
+  // the monitor's right edge. The previous `margin-left: -32px` was a
+  // workaround for PositionType.LEFT and clipped the menu's left side
+  // when the bar's tray was near the screen edge.
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 
   // ScrolledWindow (direct child)

--- a/config/styles/components/_tray.scss
+++ b/config/styles/components/_tray.scss
@@ -26,50 +26,32 @@
 // ============================================
 // Tray Menu Popover
 // ============================================
+//
+// Our tray menu is hand-rolled (see `config/left/sys-tray/menu.tsx` and
+// AUDIT C-1.16): we no longer use `Gtk.PopoverMenu.new_from_model`, so the
+// internal widget hierarchy is a plain `Gtk.Box` of `Gtk.Button`s wrapped
+// in a `Gtk.Popover`, not GTK's `modelbutton`/`scrolledwindow`/`viewport`
+// machinery. Selectors below target the css_classes we attach in code.
 
 popover.tray-menu {
   background-color: transparent;
   border: none;
   padding: 0;
   margin: 0;
-  // The popover is now anchored BOTTOM (see tray-item.tsx) and arrow is
-  // hidden, so the menu drops straight down from the tray button. No
-  // horizontal offset — GTK 4 will auto-flip if the menu would overflow
-  // the monitor's right edge. The previous `margin-left: -32px` was a
-  // workaround for PositionType.LEFT and clipped the menu's left side
-  // when the bar's tray was near the screen edge.
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 
-  // ScrolledWindow (direct child)
-  scrolledwindow {
-    background-color: transparent;
-    padding: 0;
-    margin: 0;
-    min-width: 0;
-    min-height: 0;
-    border: none;
-  }
-
-  // Viewport inside ScrolledWindow
-  viewport {
+  // Outer container drawn as the menu's "card" — border, padding, radius.
+  > contents,
+  .tray-menu-box {
     background-color: variables.$ctp-base;
     border: variables.$border-width-normal solid variables.$ctp-surface0;
     border-radius: variables.$radius-sm;
     padding: variables.$spacing-sm;
     margin: 0;
-    min-width: 0;
-    min-height: 0;
   }
 
-  // Hide scrollbars
-  scrollbar {
-    opacity: 0;
-    min-width: 0;
-    min-height: 0;
-  }
-
-  // Menu items (modelbutton is GTK's internal widget)
-  modelbutton {
+  // Each clickable row (item or submenu).
+  .tray-menu-item {
     min-height: variables.$bar-height;
     padding: variables.$spacing-sm variables.$spacing-lg;
     border-radius: variables.$spacing-sm;
@@ -86,26 +68,44 @@ popover.tray-menu {
       background-color: variables.$ctp-surface1;
     }
 
-    // Submenu indicator
-    &.has-open-popup {
-      background-color: variables.$ctp-surface0;
-
-      &:hover {
-        background-color: variables.$ctp-surface1;
-        color: variables.$ctp-mauve;
-      }
+    &:disabled {
+      opacity: 0.45;
     }
   }
 
-  // Menu separators
-  separator {
+  // Submenu rows: keep the right-pointing arrow visually distinct.
+  .tray-menu-submenu {
+    .tray-menu-trailing {
+      color: variables.$ctp-subtext0;
+    }
+
+    &:hover .tray-menu-trailing {
+      color: variables.$ctp-mauve;
+    }
+  }
+
+  .tray-menu-row {
+    // Row layout is set in code (Gtk.Box HORIZONTAL with spacing); nothing
+    // to override here, but keep the rule as an anchor for future tweaks.
+  }
+
+  .tray-menu-icon {
+    color: variables.$ctp-text;
+  }
+
+  .tray-menu-label {
+    color: variables.$ctp-text;
+  }
+
+  .tray-menu-section-label {
+    color: variables.$ctp-subtext0;
+    font-size: 0.85em;
+    padding: variables.$spacing-xs variables.$spacing-lg;
+  }
+
+  .tray-menu-separator {
     min-height: 1px;
     margin: variables.$spacing-sm variables.$spacing-md;
     background-color: variables.$ctp-surface0;
-  }
-
-  // Menu labels
-  label {
-    color: variables.$ctp-text;
   }
 }

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -1,22 +1,17 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-
-    "moduleResolution": "bundler",
-
+    "strict": true,
+    "module": "ES2022",
+    "target": "ES2020",
+    "lib": ["ES2023"],
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "jsxImportSource": "ags/gtk4",
-
-    "strict": true,
-    "skipLibCheck": true,
-
     "baseUrl": ".",
-    "paths": {
-      "ags/*": ["/home/fred/.local/share/ags/lib/*"],
-      "@girs/*": ["/home/fred/.config/ags/@girs/*"]
-    }
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true
   },
-
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }

--- a/flake.lock
+++ b/flake.lock
@@ -120,6 +120,22 @@
         "type": "github"
       }
     },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -206,6 +222,28 @@
         "flake-compat": "flake-compat_2",
         "gitignore": "gitignore_2",
         "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_3": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "gitignore": "gitignore_3",
+        "nixpkgs": [
           "precommit",
           "nixpkgs"
         ]
@@ -248,6 +286,27 @@
       }
     },
     "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_3": {
       "inputs": {
         "nixpkgs": [
           "precommit",
@@ -580,7 +639,7 @@
     "precommit_2": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "git-hooks": "git-hooks_2",
+        "git-hooks": "git-hooks_3",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -605,6 +664,7 @@
         "ags": "ags",
         "astal": "astal_2",
         "fredcal": "fredcal",
+        "git-hooks": "git-hooks_2",
         "hyprshutdown": "hyprshutdown",
         "nixpkgs": "nixpkgs_4",
         "precommit": "precommit_2"

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,16 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Needed directly because we add a project-local tsc hook that wraps
+    # the compiler in a filter (see `tsc-filtered` writeShellApplication
+    # below). The precommit framework doesn't expose a way to inject
+    # extra hooks, so we re-invoke `git-hooks.lib.run` ourselves and
+    # merge in our hook alongside the framework's.
+    git-hooks = {
+      url = "github:cachix/git-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     fredcal = {
       url = "github:FredSystems/fred-cal";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -28,6 +38,7 @@
       self,
       nixpkgs,
       precommit,
+      git-hooks,
       ags,
       astal,
       fredcal,
@@ -135,18 +146,134 @@
       ##########################################################################
       ## PRE-COMMIT CHECKS
       ##########################################################################
-      checks = lib.genAttrs systems (system: {
-        pre-commit = precommit.lib.mkCheck {
-          inherit system;
-          src = ./.;
+      #
+      # We bypass `precommit.lib.mkCheck` for one reason: the framework's
+      # built-in tsc hook runs `tsc --build <tsconfig>` and surfaces every
+      # error tsc emits, including the ~8 errors in upstream ags / gnim
+      # `.ts` sources that ship without `.d.ts` files (see
+      # `node_modules/ags/lib/gtk4/app.ts:288` for one example). Those are
+      # not bugs in our code; the canonical `ags init` template fails
+      # `tsc -p . --noEmit` straight out of the box.
+      #
+      # Rather than disabling typechecking entirely, we keep tsc as a
+      # pre-commit hook but post-filter its output to errors originating
+      # in `config/**` (excluding `config/@girs` and `config/node_modules`
+      # which contain generated / vendored code). Any error from our own
+      # source still fails the hook; upstream noise is silently dropped.
+      checks = lib.genAttrs systems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
 
-          # ── Feature toggles ─────────────────────────────
-          check_rust = false;
-          check_docker = false;
-          check_python = false;
-          check_javascript = true;
-        };
-      });
+          # Wrapper script: run tsc in project mode, then filter stderr+stdout
+          # to retain only lines pointing at fred-bar sources. Exits non-zero
+          # iff at least one such line remains.
+          tscFiltered = pkgs.writeShellApplication {
+            name = "fredbar-tsc-check";
+            runtimeInputs = [
+              pkgs.typescript
+              pkgs.gnugrep
+              pkgs.coreutils
+              # `ags types -u` regenerates `config/@girs` and the
+              # `config/node_modules/{ags,gnim}` symlinks. The hook
+              # runs inside a git-hooks sandbox where those gitignored
+              # artifacts are absent, so we regenerate them on demand.
+              ((patchedAgs system).override {
+                extraPackages = self.lib.fredbarAstalPackages system;
+              })
+            ];
+            text = ''
+              set -u
+
+              # Ensure ags-generated artifacts exist. They live in
+              # gitignored paths so are absent from a clean checkout
+              # (e.g. the pre-commit sandbox or a CI clone).
+              # `ags types -u` regenerates types AND rewrites
+              # `config/tsconfig.json` from a hard-coded template, so we
+              # save and restore the in-repo config around the call.
+              if [ ! -d "./config/@girs" ] || [ ! -L "./config/node_modules/ags" ]; then
+                cp ./config/tsconfig.json ./config/.tsconfig.json.bak
+                if ! ags types -u -d "./config" >/tmp/ags-types.log 2>&1; then
+                  mv ./config/.tsconfig.json.bak ./config/tsconfig.json
+                  printf '[tsc] %s\n' \
+                    "failed to generate ags types; tsc cannot resolve gi:// modules" >&2
+                  printf '[tsc] ags types output:\n' >&2
+                  cat /tmp/ags-types.log >&2 || true
+                  exit 1
+                fi
+                mv ./config/.tsconfig.json.bak ./config/tsconfig.json
+              fi
+
+              # Capture both streams. tsc writes errors to stdout, but be
+              # defensive in case that changes in a future release.
+              # `writeShellApplication` enables `set -e`; suppress it just
+              # for the tsc invocation so we can inspect its exit code.
+              set +e
+              raw="$(tsc -p ./config --noEmit 2>&1)"
+              rc=$?
+              set -e
+
+              # Strip lines whose error path does NOT live under our
+              # source tree. Anything outside `config/` (including
+              # paths starting with `../` that escape the cwd, e.g.
+              # `../../../nix/store/...` symlinks) or under
+              # `config/@girs/` and `config/node_modules/` is upstream
+              # noise.
+              filtered="$(printf '%s\n' "$raw" \
+                | grep -E '^(config/)' \
+                | grep -vE '^config/(@girs|node_modules)/' \
+                || true)"
+
+              if [ -n "$filtered" ]; then
+                printf '%s\n' "$filtered"
+                exit 1
+              fi
+
+              # tsc exited non-zero but every error was upstream. Still
+              # report a green light, but log a one-line note so it's
+              # not silent.
+              if [ "$rc" -ne 0 ]; then
+                printf '[tsc] %s\n' \
+                  "passed (upstream-only errors filtered out)" >&2
+              fi
+              exit 0
+            '';
+          };
+
+          baseMod = precommit.lib.mkBaseCheck { inherit system; };
+          jsMod = precommit.lib.mkJavascriptCheck {
+            inherit system;
+            enableBiome = true;
+            enableTsc = false; # we provide our own filtered hook below
+          };
+
+          extraHook = {
+            tsc-fredbar = {
+              enable = true;
+              entry = "${tscFiltered}/bin/fredbar-tsc-check";
+              files = "\\.(ts|tsx)$";
+              pass_filenames = false;
+            };
+          };
+
+          hooks = baseMod.hooks // jsMod.hooks // extraHook;
+          excludes = baseMod.excludes ++ jsMod.excludes;
+
+          run = git-hooks.lib.${system}.run {
+            src = ./.;
+            inherit hooks excludes;
+          };
+        in
+        {
+          pre-commit = run // {
+            passthru = {
+              devPackages = baseMod.passthru.devPackages ++ jsMod.passthru.devPackages ++ [ tscFiltered ];
+              libPath = baseMod.passthru.libPath ++ jsMod.passthru.libPath;
+            };
+            enabledPackages = run.enabledPackages or [ ];
+          };
+        }
+      );
 
       ##########################################################################
       ## DEV SHELL
@@ -175,6 +302,9 @@
                 # `G_DEBUG=fatal-criticals` so the first GLib-CRITICAL halts
                 # the process in gdb.
                 gdb
+                # TypeScript compiler for typechecking config/ (ags doesn't
+                # typecheck at runtime). Invoke with: `tsc -p config --noEmit`.
+                typescript
                 ((patchedAgs system).override {
                   extraPackages = self.lib.fredbarAstalPackages system;
                 })
@@ -186,6 +316,22 @@
               ${chk.shellHook}
 
               alias pre-commit="pre-commit run --all-files"
+
+              # Generate TypeScript types and link the ags / gnim packages
+              # into config/node_modules. `ags types -u` is idempotent but
+              # ALSO rewrites config/tsconfig.json from a hard-coded ags
+              # template, clobbering our in-repo settings (baseUrl,
+              # skipLibCheck, etc.). Save and restore around the call.
+              if [ ! -d "$PWD/config/@girs" ] || [ ! -L "$PWD/config/node_modules/ags" ]; then
+                echo "[fred-bar] generating ags TypeScript types..." >&2
+                cp "$PWD/config/tsconfig.json" "$PWD/config/.tsconfig.json.bak"
+                if ags types -u -d "$PWD/config" >/dev/null 2>&1; then
+                  mv "$PWD/config/.tsconfig.json.bak" "$PWD/config/tsconfig.json"
+                else
+                  mv "$PWD/config/.tsconfig.json.bak" "$PWD/config/tsconfig.json"
+                  echo "[fred-bar] WARNING: 'ags types -u' failed; tsc will not resolve ags modules" >&2
+                fi
+              fi
             '';
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -170,6 +170,11 @@
                 typos
                 nixfmt
                 markdownlint-cli2
+                # Debugger for tracking down gjs/GLib refcount underflows and
+                # segfaults that have no JS-side backtrace. Pair with
+                # `G_DEBUG=fatal-criticals` so the first GLib-CRITICAL halts
+                # the process in gdb.
+                gdb
                 ((patchedAgs system).override {
                   extraPackages = self.lib.fredbarAstalPackages system;
                 })


### PR DESCRIPTION
## Summary

Closes out **AUDIT.md** in full: every `C-1.*` (correctness), `C-2.*` (performance), and `C-3.*` (architecture) item is now resolved. 33 commits, branched off main after PRs #35/#31.

## Highlights

### Correctness (C-1.*)
- Notifications: honor `transient` and `x-canonical-private-synchronous` hints; popups on focused monitor only with follow-mouse reparenting.
- Compositors: live window-title updates; Niri now subscribes to `niri msg --json event-stream` instead of 200ms polling.
- Tray: bypass appmenu-glib-translator with a direct `com.canonical.dbusmenu` client; correct inter-icon transitions; menus drop downward.
- Audio: collapse duplicate `notify::default-speaker` handlers.
- Workspaces: debounce hover collapse to break revealer oscillation.
- Bar: click anywhere dismisses open panels.

### Performance (C-2.*)
- System-state poll dedupes output (suppresses 4Hz churn).
- Battery drops redundant 2s poll, relies on `notify::*`.
- Tooltip caches widget tree across `query-tooltip`.
- Media player rebinds on player swap instead of full rebuild.
- Sliders: async ddcutil detection + per-slider `getvcp`.
- AppInfo enumeration cached; themed-icon fallbacks.

### Architecture (C-3.*)
- Centralised VPN polling + compositor detection.
- Shared `getMonitorConnectorName` helper.
- Tagged logger with `AGS_LOG_LEVEL` gate.
- Time-pill clock entries keyed by label (avoids tzid collisions).
- Self-driving widget cleanup via `destroy` signal.
- **C-3.5 (final item):** strict tsc now CI-gated via pre-commit. 19 `as unknown as { ... }` casts collapsed to 2 unavoidable ones, backed by real types from upstream ags + gnim. Portable type generation via `ags types -u` in the dev shell (with tsconfig backup/restore around the call, since ags clobbers it). 5 real bugs surfaced and fixed along the way.

## Verification

- `pre-commit run --all-files` green from a cold checkout (artifacts regenerated by shellHook).
- Live-tested on the four-monitor rig: media, bluetooth, notifications, tray menus, all panels.