### PR TITLE
chore(flake/astal): `67ddc83e` -> `d8738f97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -75,11 +75,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1777578913,
-        "narHash": "sha256-2Hzr8T4oUtw2q0ZYxrgDB8kvy85QawlhpiQDk4eGOHQ=",
+        "lastModified": 1779465550,
+        "narHash": "sha256-lsLyO08Gv9eLvUYd6I+UUuZeT4w5M1vU/ulo5QICoNo=",
         "owner": "Aylur",
         "repo": "astal",
-        "rev": "67ddc83e0bdbda6de7f6f15e4fbc5d6b9d2d1b18",
+        "rev": "d8738f97ed01f4d87f668df35fa7bbad795c9e49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                       | Message                                                                          |
| -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`d8738f97`](https://github.com/Aylur/astal/commit/d8738f97ed01f4d87f668df35fa7bbad795c9e49) | `` chore: migrate mpris cli to libquarrel ``                                     |
| [`76774657`](https://github.com/Aylur/astal/commit/76774657b9c5c6a4aae1ec746ab09245cbdf1d0b) | `` chore: format ``                                                              |
| [`8faa6dd4`](https://github.com/Aylur/astal/commit/8faa6dd4fa7ab8e1f83dd064f24ec5c22f9de30f) | `` fix(mpris): disable early notifications ``                                    |
| [`b4167b4c`](https://github.com/Aylur/astal/commit/b4167b4c7bec62e50711636d8ea8e7c24fa0790c) | `` fix: gir.py valadoc invocation ``                                             |
| [`dd388d20`](https://github.com/Aylur/astal/commit/dd388d209e71b44d9dff130261c8fe1658c24ae2) | `` docs(notifd): add quarrel notice ``                                           |
| [`2cd7aa31`](https://github.com/Aylur/astal/commit/2cd7aa31f52748eb993d01de43d3086c7b352a32) | `` docs: brightness library ``                                                   |
| [`e13855a5`](https://github.com/Aylur/astal/commit/e13855a58bd761f322fb16e06e85e340d7fb476b) | `` init: brightness library ``                                                   |
| [`31397bc2`](https://github.com/Aylur/astal/commit/31397bc288d26f9107f80d38f08aec14004f11af) | `` fix(quarrel): sort subcommands in help output by the order they were added `` |
| [`71627856`](https://github.com/Aylur/astal/commit/716278562cc467b069ea0c443227357ad0e3937d) | `` fix(notifd-cli): handle unix signals ``                                       |
| [`6a01f19a`](https://github.com/Aylur/astal/commit/6a01f19ab3d77cdac7db3b3a185e74e81828c581) | `` feat(notifd): Notifd ListModel implementation ``                              |
| [`75e98e67`](https://github.com/Aylur/astal/commit/75e98e67db43237f4070cc559c7a48ad06dd56e8) | `` feat(quarrel): FloatOpt -> DoubleOpt ``                                       |
| [`a1fbc4a1`](https://github.com/Aylur/astal/commit/a1fbc4a1d6c6aec9b940f275dd91bdb52888d911) | `` fix(notifd): grammar ``                                                       |
| [`8aea69bd`](https://github.com/Aylur/astal/commit/8aea69bd4de0c9a5ae1a821c115aeff2df28434d) | `` feat(notifd): introduce new cli using libquarrel ``                           |
| [`8cc30eaf`](https://github.com/Aylur/astal/commit/8cc30eaf4744ab34419b84af65e93d8b42e3afe6) | `` feat(quarrel): unknown command error ``                                       |
| [`f415d1f3`](https://github.com/Aylur/astal/commit/f415d1f3c7d229688762dd6ea311435b4041ec6b) | `` nix: read gsettings path set by devshell ``                                   |
| [`244ca325`](https://github.com/Aylur/astal/commit/244ca325991ea177713d0c696e95b7b57c544888) | `` fix(quarrel) omit null names ``                                               |
| [`29584a45`](https://github.com/Aylur/astal/commit/29584a45ce18e1f0dd541167aa3d68a5939a3c2f) | `` fix(notifd): use add_action on deserialization ``                             |