### PR TITLE
chore(flake/nixpkgs): `549bd84d` -> `64c08a7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -582,11 +582,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`48412697`](https://github.com/NixOS/nixpkgs/commit/48412697e89d6e9bc7837eb420bc44b1e313244c) | `` netbird: 0.71.3 -> 0.71.4 ``                                                                      |
| [`5a37f4ec`](https://github.com/NixOS/nixpkgs/commit/5a37f4eca8c2c9e7004d4d1d44b881ba069908d1) | `` qui: 1.18.0 -> 1.19.0 ``                                                                          |
| [`de33a4ea`](https://github.com/NixOS/nixpkgs/commit/de33a4ea3785cca83ff5a5965c0f1652124338cf) | `` updatecli: 0.116.3 -> 0.117.0 ``                                                                  |
| [`2f50367e`](https://github.com/NixOS/nixpkgs/commit/2f50367ee5158d50a9b82ace2b197b4b08710af8) | `` apidog: 2.8.28 -> 2.8.30 ``                                                                       |
| [`ebc16523`](https://github.com/NixOS/nixpkgs/commit/ebc165237166e4f23e47a3539678b2b5a6d99ead) | `` xqilla: enable parallel building ``                                                               |
| [`ef379833`](https://github.com/NixOS/nixpkgs/commit/ef379833724d1aef27a05223f0f92e51a77a039a) | `` rtk: 0.40.0 -> 0.41.0 ``                                                                          |
| [`2d8469b0`](https://github.com/NixOS/nixpkgs/commit/2d8469b0101800134c1ceeea7c5777927dd51deb) | `` home-assistant-custom-components.closest_intent: init at 0.1.0 ``                                 |
| [`2fa56d6e`](https://github.com/NixOS/nixpkgs/commit/2fa56d6e1ea9d3220237c80c55a5591cfeac195b) | `` streamcontroller: 1.5.0-beta.13 -> 1.5.0-beta.14 ``                                               |
| [`227390cd`](https://github.com/NixOS/nixpkgs/commit/227390cd4794adf1932ab9f4c7014f2a8ef0364f) | `` home-assistant-custom-components.local_openai: init at 1.6.0 ``                                   |
| [`7bfd4f2a`](https://github.com/NixOS/nixpkgs/commit/7bfd4f2adfe8e5f048930766d159948df19c099d) | `` home-assistant-custom-components.mypyllant: 0.9.12 -> 0.9.13 ``                                   |
| [`297e7591`](https://github.com/NixOS/nixpkgs/commit/297e75917e9c0e1f0e9fc8f606c9c5585ab32a70) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.332 -> 0.13.333 ``         |
| [`466a800c`](https://github.com/NixOS/nixpkgs/commit/466a800c2b71a1e11d153e1682a03f01dfbf03dc) | `` python314Packages.homeassistant-stubs: 2026.5.3 -> 2026.5.4 ``                                    |
| [`a7ced727`](https://github.com/NixOS/nixpkgs/commit/a7ced7272ec8b3f3850e1a45197fb787b8c2611c) | `` home-assistant-custom-components.yandex-station: 3.20.3 -> 3.21.1 ``                              |
| [`bb0fa7f6`](https://github.com/NixOS/nixpkgs/commit/bb0fa7f67f47831d0aca96d9c670743f0d11bf84) | `` home-assistant-custom-components.oref_alert: 6.18.2 -> 6.18.3 ``                                  |
| [`b37108be`](https://github.com/NixOS/nixpkgs/commit/b37108be35826d7b071002e4b6188bb0b3dd7207) | `` home-assistant-custom-components.garmin_connect: 3.0.7 -> 3.0.8 ``                                |
| [`6bbd96dd`](https://github.com/NixOS/nixpkgs/commit/6bbd96dd7b73879c18b048b4e34f9bcda0dccf46) | `` python3Packages.ha-garmin: 0.1.22 -> 0.1.23 ``                                                    |
| [`32cc9809`](https://github.com/NixOS/nixpkgs/commit/32cc9809bf4bbefbb280a50eae0268d1032a438c) | `` home-assistant-custom-components.entity-notes: 3.3.4 -> 3.3.10 ``                                 |
| [`95c37c86`](https://github.com/NixOS/nixpkgs/commit/95c37c86b21d562286bf330197390284dfa29d83) | `` home-assistant-custom-components.alarmo: 1.10.17 -> 1.10.18 ``                                    |
| [`31ca7d37`](https://github.com/NixOS/nixpkgs/commit/31ca7d375344e62df00b7160aa8792097d59c8cd) | `` home-assistant: 2026.5.3 -> 2026.5.4 ``                                                           |
| [`e18c3ff6`](https://github.com/NixOS/nixpkgs/commit/e18c3ff6bfe29d385cc0065cdf3cd4381b849935) | `` python3Packages.wled: 0.22.0 -> 0.23.0 ``                                                         |
| [`b73acd96`](https://github.com/NixOS/nixpkgs/commit/b73acd96949ccbc124721c6aa74d71e2cb3cf7d4) | `` python3Packages.python-backoff: init at 2.3.1 ``                                                  |
| [`e875e2a1`](https://github.com/NixOS/nixpkgs/commit/e875e2a1f3951b5b2cda249bf7657ddb3450987c) | `` python3Packages.renault-api: 0.5.8 -> 0.5.10 ``                                                   |
| [`e956b9e3`](https://github.com/NixOS/nixpkgs/commit/e956b9e3b1769631f98ae6d0d51a9143402307f9) | `` python3Packages.python-roborock: 5.5.1 -> 5.12.0 ``                                               |
| [`3821e9e8`](https://github.com/NixOS/nixpkgs/commit/3821e9e8bc1cace1569c0f3015393536bbd62484) | `` python3Packages.aiolyric: 2.1.0 -> 2.1.1 ``                                                       |
| [`71fa9158`](https://github.com/NixOS/nixpkgs/commit/71fa9158c78ca9348ec8f6bee7dbae7826ca4417) | `` python3Packages.pycyphal: disable doctests broken by asyncio task leaks on python 3.14 ``         |
| [`2622050d`](https://github.com/NixOS/nixpkgs/commit/2622050d916555458a7c0c352aea82060a9fcc8e) | `` Revert "mdbook: 0.5.2 -> 0.5.3" ``                                                                |
| [`69004d6c`](https://github.com/NixOS/nixpkgs/commit/69004d6c9b80163a6676cefc2b163916fcc818a2) | `` qwen-code: 0.15.11 -> 0.16.0 ``                                                                   |
| [`452f7ac7`](https://github.com/NixOS/nixpkgs/commit/452f7ac753cff5a9ca2d685f84385c5d1296b00c) | `` python3Packages.sigrok: fix build with swig 4.4 ``                                                |
| [`754c1c76`](https://github.com/NixOS/nixpkgs/commit/754c1c760e7f0212965f0f8f98b841bdb7d18425) | `` execline.manpages: 2.9.8.1.3 -> 2.9.9.1.1 ``                                                      |
| [`8b48b20a`](https://github.com/NixOS/nixpkgs/commit/8b48b20abdd87d5b6e2093c61099f5399c3449e4) | `` tipidee: 0.0.7.1 -> 0.0.7.2 ``                                                                    |
| [`7875de5f`](https://github.com/NixOS/nixpkgs/commit/7875de5f5d6234bcd5fca63ce325d9b7b766b8bb) | `` mdevd: 0.1.8.1 -> 0.1.8.2 ``                                                                      |
| [`4ba25795`](https://github.com/NixOS/nixpkgs/commit/4ba2579545b1ed4908c0bf9f86a187103478f614) | `` s6-networking: 2.7.2.1 -> 2.8.0.0 ``                                                              |
| [`1849d5f6`](https://github.com/NixOS/nixpkgs/commit/1849d5f660994a020e085b4efea5fbad9edf69d3) | `` s6-dns: 2.4.1.1 -> 2.4.1.2 ``                                                                     |
| [`cc306432`](https://github.com/NixOS/nixpkgs/commit/cc306432861192940d12ea08d97aced089060dfc) | `` s6-linux-utils: 2.6.4.0 -> 2.6.4.1 ``                                                             |
| [`e5c136b8`](https://github.com/NixOS/nixpkgs/commit/e5c136b862accbb3b0ca243ac5d0d0b45c782ffc) | `` s6-portable-utils: 2.3.1.1 -> 2.3.1.2 ``                                                          |
| [`514f6d2c`](https://github.com/NixOS/nixpkgs/commit/514f6d2cf2a9992b48d2eab66ed2c1ef55270b22) | `` s6-linux-init: 1.2.0.0 -> 1.2.0.1 ``                                                              |
| [`84dfce20`](https://github.com/NixOS/nixpkgs/commit/84dfce20a052c36abf5210ae1a02cda30fafcc8f) | `` s6-rc: 0.6.0.0 -> 0.6.1.1 ``                                                                      |
| [`baeb831e`](https://github.com/NixOS/nixpkgs/commit/baeb831e165a8a910ee8cde3223d1a500ebd0679) | `` s6: 2.14.0.1 -> 2.15.0.0 ``                                                                       |
| [`d7fa5fca`](https://github.com/NixOS/nixpkgs/commit/d7fa5fca04bb55c1bdcbc258d3440dec378b5704) | `` execline: 2.9.8.1 -> 2.9.9.1 ``                                                                   |
| [`0938eafb`](https://github.com/NixOS/nixpkgs/commit/0938eafb082a9f14cd473a6095c5adfc0f3a8ac7) | `` utmps: 0.1.3.2 -> 0.1.3.3 ``                                                                      |
| [`a357cebe`](https://github.com/NixOS/nixpkgs/commit/a357cebeccabf5cd87389cc341898a88596de50a) | `` nsss: 0.2.1.1 -> 0.2.1.2 ``                                                                       |
| [`b4ce6d1a`](https://github.com/NixOS/nixpkgs/commit/b4ce6d1a90ec81bf6c744630c6eb260d54421362) | `` skalibs: 2.14.5.1 -> 2.15.0.0 ``                                                                  |
| [`d12f36bf`](https://github.com/NixOS/nixpkgs/commit/d12f36bf2189015c0874459ae42f4c1a1f1d51ea) | `` pihole-web: 6.4.1 -> 6.5 ``                                                                       |
| [`00073245`](https://github.com/NixOS/nixpkgs/commit/00073245bc1d9160b1f1b2abde4028c723e9ff4f) | `` linux_6_6: 6.6.140 -> 6.6.141 ``                                                                  |
| [`802bd350`](https://github.com/NixOS/nixpkgs/commit/802bd3500a12257fae31787c268fb37da2c45fed) | `` linux_6_12: 6.12.90 -> 6.12.91 ``                                                                 |
| [`8bd16a68`](https://github.com/NixOS/nixpkgs/commit/8bd16a6891b63143c89e67fec71d39be32dfcc7e) | `` linux_6_18: 6.18.32 -> 6.18.33 ``                                                                 |
| [`60084bc7`](https://github.com/NixOS/nixpkgs/commit/60084bc78f912b0d8ad2eb440cdc8d2562756e05) | `` linux_7_0: 7.0.9 -> 7.0.10 ``                                                                     |
| [`aac1bea2`](https://github.com/NixOS/nixpkgs/commit/aac1bea2f5cec90280d1978aa5f7f726b0f6c40c) | `` resterm: 0.39.3 -> 0.39.5 ``                                                                      |
| [`1d6a5191`](https://github.com/NixOS/nixpkgs/commit/1d6a51916f0db54362607477e9d678abac5cf203) | `` python3Packages.cadwyn: 6.2.0 -> 6.2.2 ``                                                         |
| [`e01d6575`](https://github.com/NixOS/nixpkgs/commit/e01d65753bf7db6f1cd38736ce5f22a90c180916) | `` mcdreforged: cleanup ``                                                                           |
| [`5cb52e21`](https://github.com/NixOS/nixpkgs/commit/5cb52e21868458115f297228f8edbdc9129373bf) | `` mcdreforged: fix build ``                                                                         |
| [`82ed78a9`](https://github.com/NixOS/nixpkgs/commit/82ed78a9ee81eada31b619ebcdbb248daa123b9a) | `` nixos/gdm: add warning for Pulseaudio + gdm ``                                                    |
| [`9d1626ac`](https://github.com/NixOS/nixpkgs/commit/9d1626acb2c16c60b700548f689240d6918b06ef) | `` solanum: 0-unstable-2026-05-13 -> 0-unstable-2026-05-23 ``                                        |
| [`2b9f291a`](https://github.com/NixOS/nixpkgs/commit/2b9f291a4d18deea98038f71db622de7b4b94d69) | `` atril: 1.28.4 -> 1.28.5 ``                                                                        |
| [`8fb72822`](https://github.com/NixOS/nixpkgs/commit/8fb728225955b8f0afbd41da634bdc8bdaaf7997) | `` hot-resize: 0.1.6 -> 0.1.7 ``                                                                     |
| [`bde39b04`](https://github.com/NixOS/nixpkgs/commit/bde39b04eda5984de5a6d0df2890a7ac80ba9c6f) | `` python3Packages.aioamazondevices: 13.5.0 -> 13.7.2 ``                                             |
| [`f4ed0add`](https://github.com/NixOS/nixpkgs/commit/f4ed0add00aaaed1d706e7681399c264b3c19e61) | `` hyprlandPlugins.hypr-darkwindow: 0.54.3 -> 0.55.2 ``                                              |
| [`47e19f5f`](https://github.com/NixOS/nixpkgs/commit/47e19f5f91a9d3eebd7a6e5f117fba494e56a8c1) | `` nixos/containers: fix default gateway with privateNetwork ``                                      |
| [`2c48a021`](https://github.com/NixOS/nixpkgs/commit/2c48a021b24208c946db0b17ffb9cce004d3fcc1) | `` better-commits: 1.23.0 -> 1.23.1 ``                                                               |
| [`51552f84`](https://github.com/NixOS/nixpkgs/commit/51552f84ca8d2fa2cc74fabd86ba299a309a12c8) | `` python3Packages.nextcord: 3.1.1 -> 3.2.0 ``                                                       |
| [`7db9ff04`](https://github.com/NixOS/nixpkgs/commit/7db9ff04d54b01da28e3e71f53b1e9ae2e98aff9) | `` pi-coding-agent: 0.75.3 -> 0.75.4 ``                                                              |
| [`234afb7b`](https://github.com/NixOS/nixpkgs/commit/234afb7b18de2d088c2ad536bd6e94cb189ecc52) | `` hooky: fix build with kdl-hs 1.1 ``                                                               |
| [`9c081c46`](https://github.com/NixOS/nixpkgs/commit/9c081c4653f7e40dd30ba88fa898891100223c36) | `` atlauncher: fix aarch64-linux build ``                                                            |
| [`0a4b21c7`](https://github.com/NixOS/nixpkgs/commit/0a4b21c747c259de727cec2543ef412c18c026ad) | `` bark-server: 2.3.4 -> 2.3.5 ``                                                                    |
| [`bb617e6f`](https://github.com/NixOS/nixpkgs/commit/bb617e6fdf7ec98e9a7671dcec146f183fbd929f) | `` labwc-tweaks-gtk: 0-unstable-2026-05-09 -> 0-unstable-2026-05-22 ``                               |
| [`d65495fe`](https://github.com/NixOS/nixpkgs/commit/d65495fe777d7e249b973568590615d6a2124bbe) | `` jetbrains.webstorm: 2026.1.1 -> 2026.1.2 ``                                                       |
| [`308c3c35`](https://github.com/NixOS/nixpkgs/commit/308c3c352cdbda17ab08b750886d3b5895018a05) | `` nginx: 1.30.1 -> 1.30.2 ``                                                                        |
| [`a56e5e28`](https://github.com/NixOS/nixpkgs/commit/a56e5e28a549a7d217ae3901a4cecfc2813d0f20) | `` python3Packages.jsonschema-rs: set __darwinAllowLocalNetworking ``                                |
| [`f669e5b8`](https://github.com/NixOS/nixpkgs/commit/f669e5b809cd9a4315c1b80c10a77a8f6500e3cb) | `` android-studio-for-platform: stable 2024.2.2.13 -> 2025.3.2.6, canary 2024.3.1.9 -> 2026.1.2.1 `` |
| [`be3620d1`](https://github.com/NixOS/nixpkgs/commit/be3620d19fe11673f84ceb67e6fefda36a161049) | `` open-webui: remove --legacy-peer-deps ``                                                          |
| [`82eaf694`](https://github.com/NixOS/nixpkgs/commit/82eaf69469a5fb2e86993eba825d1c8a8410eb45) | `` deja: 0.2.5 -> 0.2.6 ``                                                                           |
| [`ae8284b8`](https://github.com/NixOS/nixpkgs/commit/ae8284b80c49dea96d21b134081506ec6b4139a8) | `` wcslib: 8.7 -> 8.8 ``                                                                             |
| [`9c47d312`](https://github.com/NixOS/nixpkgs/commit/9c47d3127c7a49202063e6094191e832aa5db074) | `` python3Packages.agentic-threat-hunting-framework: 0.12.0 -> 0.13.0 ``                             |
| [`a00f79b5`](https://github.com/NixOS/nixpkgs/commit/a00f79b5e701ac5a683f0b519660ff56be3ea82b) | `` exploitdb: 2026-05-16 -> 2026-05-22 ``                                                            |
| [`6b9d6878`](https://github.com/NixOS/nixpkgs/commit/6b9d6878d062b388770b9c43e9ba16c3113d451a) | `` libretro.mupen64plus: 0-unstable-2026-05-12 -> 0-unstable-2026-05-20 ``                           |
| [`09be9bde`](https://github.com/NixOS/nixpkgs/commit/09be9bde87024f43fc893c4f0a2f6a5a8f16fa7d) | `` python3Pakcages.aiocsv: modernize ``                                                              |
| [`14d693c1`](https://github.com/NixOS/nixpkgs/commit/14d693c140c7051cbdd2dc60d193b37d46e2759c) | `` sahel-fonts: add pancaek as maintainer ``                                                         |
| [`13cbb0c1`](https://github.com/NixOS/nixpkgs/commit/13cbb0c1c0e5723fb0c75e00acd8ae5357542c34) | `` sahel-fonts: use installFonts ``                                                                  |
| [`660f9a8e`](https://github.com/NixOS/nixpkgs/commit/660f9a8edf07049eeeae99406ff252f784aebac0) | `` python3Packages.garminconnect: migrate to finalAttrs ``                                           |
| [`97096dae`](https://github.com/NixOS/nixpkgs/commit/97096daea4d8a24103b30cdc77e0763ba4137899) | `` typesetter: 0.12.6 -> 0.13.1 ``                                                                   |
| [`9cd4feed`](https://github.com/NixOS/nixpkgs/commit/9cd4feedd5fc5953751377a26cba8ddc54b7913e) | `` fragment-mono: use installFonts ``                                                                |
| [`c88cfc38`](https://github.com/NixOS/nixpkgs/commit/c88cfc3862b25647e64c667f538e8e067687e583) | `` python3Packages.aiocsv: 1.4.0 -> 1.4.1 ``                                                         |
| [`7107e41d`](https://github.com/NixOS/nixpkgs/commit/7107e41d66ab3671b9fe824a6aa9f9b7a55ea513) | `` ip2unix: 2.2.1 -> 2.2.2 ``                                                                        |
| [`b0ca8e91`](https://github.com/NixOS/nixpkgs/commit/b0ca8e91d2e804d2df7dede1de8e155c87cd2445) | `` python3Packages.withings-sync: 5.3.2 -> 6.0.2 ``                                                  |
| [`42edbe31`](https://github.com/NixOS/nixpkgs/commit/42edbe3108ecceea70098b98afb7fa7dd9439d14) | `` python3Packages.garminconnect: remove unnecessary withings-sync dependency ``                     |
| [`98817ee9`](https://github.com/NixOS/nixpkgs/commit/98817ee929bddb5203c51e847a67937b272c55f1) | `` kiesel: init at 0.2.0 ``                                                                          |
| [`d00c6e09`](https://github.com/NixOS/nixpkgs/commit/d00c6e09404ad231acfacec67253240b831bcbbc) | `` python3Packages.git-url-parse: modernize and migrate to pyproject ``                              |
| [`35441e44`](https://github.com/NixOS/nixpkgs/commit/35441e44e9e0b9fe7f92983c380b4120adf7afe7) | `` python3Packages.unittest-data-provider: drop ``                                                   |
| [`9a763ad0`](https://github.com/NixOS/nixpkgs/commit/9a763ad07bb1ec49cb4eff828bc31cdd59cb3dd6) | `` postgrest: 14.11 -> 14.12 ``                                                                      |
| [`e12a3d93`](https://github.com/NixOS/nixpkgs/commit/e12a3d936fa5909f3b417248df1f9a638f1d4724) | `` python3Packages.tstr: 0.4.0.post1 -> 0.4.1 ``                                                     |
| [`0b00dcb6`](https://github.com/NixOS/nixpkgs/commit/0b00dcb6dfb36210684f519c3d336c2f33fe0d5a) | `` uv: 0.11.15 -> 0.11.16 ``                                                                         |
| [`5471a6a1`](https://github.com/NixOS/nixpkgs/commit/5471a6a1fef474aec83073f39af38f1641968cb2) | `` smpmgr: include all smpclient transports ``                                                       |
| [`b5cb6b27`](https://github.com/NixOS/nixpkgs/commit/b5cb6b27f202fc417f9fe78e09af45621816a53c) | `` python3Packages.smp: pin pyproject.toml version ``                                                |
| [`281cf61b`](https://github.com/NixOS/nixpkgs/commit/281cf61b41b35d9bd146d9f5502a7c60f2115d69) | `` python3Packages.smpclient: 6.0.0 -> 7.0.1 ``                                                      |
| [`79ca1dd2`](https://github.com/NixOS/nixpkgs/commit/79ca1dd2b541795da8cdabac5d7df6fa87ab42a2) | `` wgsl-analyzer: 2026-03-13 -> 2026-04-26 ``                                                        |
| [`5bc550b3`](https://github.com/NixOS/nixpkgs/commit/5bc550b3c13831f9d78420d6437fef3c3859e36e) | `` nginxMainline: 1.31.0 -> 1.31.1 ``                                                                |
| [`b0015daf`](https://github.com/NixOS/nixpkgs/commit/b0015daf6f63118f98ef4bd287ed6bb66efe3f96) | `` cudaPackages.tensorrt: mark insecure ``                                                           |
| [`48f9d065`](https://github.com/NixOS/nixpkgs/commit/48f9d0652e55892b6e10094ecafebde01baf481b) | `` owi: 0.2-unstable-2026-05-05 -> 0.2-unstable-2026-05-22 ``                                        |
| [`997f14e0`](https://github.com/NixOS/nixpkgs/commit/997f14e05930904791153781065d72f7bec51b48) | `` vimcats: 1.1.1 -> 1.2.0 ``                                                                        |
| [`a31044f8`](https://github.com/NixOS/nixpkgs/commit/a31044f84b8fe475c7846925022c0bc83bb462cd) | `` python3Packages.pip-requirements-parser: modernize ``                                             |
| [`e6afb4a3`](https://github.com/NixOS/nixpkgs/commit/e6afb4a32c6891c7b6ede116c3c47663ee50e36e) | `` python3Packages.pip-requirements-parser: fix build with packaging 26 ``                           |
| [`12f94ebc`](https://github.com/NixOS/nixpkgs/commit/12f94ebc9f13187ed82569bfe011673146bdbdae) | `` linuxKernel.kernels.linux_zen: 7.0.9-zen1 -> 7.0.9-zen2 ``                                        |
| [`5e77f648`](https://github.com/NixOS/nixpkgs/commit/5e77f648880ea9bd450b073c16b076f097bf27c4) | `` libaec: switch source to github ``                                                                |
| [`4f46cab3`](https://github.com/NixOS/nixpkgs/commit/4f46cab38cc108f8c7786c5f8b521bac5710617a) | `` aws-sam-cli: 1.154.0 -> 1.160.0 ``                                                                |
| [`b941cbeb`](https://github.com/NixOS/nixpkgs/commit/b941cbeb2ba4afbb5a491d266cac4135762f0c76) | `` python3Packages.crossandra: 2.2.1 -> 2.3.0 ``                                                     |
| [`07ab328c`](https://github.com/NixOS/nixpkgs/commit/07ab328c3fbc0ccc18b337adf4a7b2eeb37ae42d) | `` zeekscript: 1.3.4 -> 1.3.6 ``                                                                     |
| [`261cdb2d`](https://github.com/NixOS/nixpkgs/commit/261cdb2da56b1d971e6f05c4c6ddf92e43bbe925) | `` dwproton-bin: dwproton-11.0-1 -> dwproton-11.0-2 ``                                               |
| [`72589a56`](https://github.com/NixOS/nixpkgs/commit/72589a5689b9177f2570e908c59fbe2f5d9a8c27) | `` rgl: 0.17.0 -> 0.18.0 ``                                                                          |
| [`79d21004`](https://github.com/NixOS/nixpkgs/commit/79d21004a23e2927ea8b479da3128b5bf9e8ba91) | `` mirrord: 3.210.0 -> 3.211.0 ``                                                                    |
| [`4a5eaa76`](https://github.com/NixOS/nixpkgs/commit/4a5eaa766f4c3a5dccb707d7a348ce5b6322ff89) | `` python3Packages.pydantic-ai-slim: 1.97.0 -> 1.101.0 ``                                            |
| [`7f99bf80`](https://github.com/NixOS/nixpkgs/commit/7f99bf800968d81495742d98870571b6a50fe911) | `` python3Packages.pydantic-graph: 1.97.0 -> 1.101.0 ``                                              |
| [`cce18fae`](https://github.com/NixOS/nixpkgs/commit/cce18faeb0179bfe225926c0f2aa9753aefbd404) | `` libretro.prboom: 0-unstable-2026-05-04 -> 0-unstable-2026-05-20 ``                                |
| [`94725a66`](https://github.com/NixOS/nixpkgs/commit/94725a66cee78a982ff055825dc020260c598a0f) | `` home-assistant-custom-lovelace-modules.zigbee2mqtt-networkmap: 0.10.0 -> 0.13.0 ``                |
| [`3a624316`](https://github.com/NixOS/nixpkgs/commit/3a624316e3161cd4550757880bc5ccc51393581d) | `` deja: init at 0.2.6 ``                                                                            |
| [`7a47d24f`](https://github.com/NixOS/nixpkgs/commit/7a47d24ff4d466e8d748f00ff6b0f47158127a94) | `` libretro.mame2000: 0-unstable-2026-03-31 -> 0-unstable-2026-05-22 ``                              |
| [`ec807151`](https://github.com/NixOS/nixpkgs/commit/ec807151c27918395068c66a416e4e269674d421) | `` home-assistant-custom-components.elegoo_printer: 2.8.0 -> 2.9.0 ``                                |
| [`d8663800`](https://github.com/NixOS/nixpkgs/commit/d8663800f6a63c7088e8e2997739bdf0008d54f0) | `` os-agent: 1.8.1 -> 1.9.0 ``                                                                       |
| [`b3b4645f`](https://github.com/NixOS/nixpkgs/commit/b3b4645f0cf7c11755bacb7698ad283db7dd3210) | `` xonsh: 0.23.5 -> 0.23.7 ``                                                                        |
| [`1e56caa3`](https://github.com/NixOS/nixpkgs/commit/1e56caa34bb1f9ea0153a641bc8cfcc7ff30d50e) | `` hello: fix translations on FreeBSD ``                                                             |
| [`64819976`](https://github.com/NixOS/nixpkgs/commit/648199765f51aa9c5bfdfeebc8a87f7ffc9dfa1e) | `` python3Packages.homematicip: remove disabled ``                                                   |
| [`d49a732b`](https://github.com/NixOS/nixpkgs/commit/d49a732b377ed01c0de2b13c1dde030ca9e6d939) | `` copilot-language-server: 1.487.0 -> 1.495.0 ``                                                    |
| [`98086d4d`](https://github.com/NixOS/nixpkgs/commit/98086d4dcfbcb53afb31b474c5c2c510451456b8) | `` nwg-panel: 0.10.13 -> 0.10.15 ``                                                                  |
| [`cbd1db0a`](https://github.com/NixOS/nixpkgs/commit/cbd1db0ad7f6aacdfb8d0b0aa5c97f54089bdf89) | `` hledger-fmt: 0.3.8 -> 0.3.9 ``                                                                    |
| [`d2ea1ace`](https://github.com/NixOS/nixpkgs/commit/d2ea1ace635737c4d4efe66ffe7a1d90507ae5c5) | `` starlark: 0-unstable-2026-03-26 -> 0-unstable-2026-05-22 ``                                       |
| [`1e4eae94`](https://github.com/NixOS/nixpkgs/commit/1e4eae9424e611d5eb045b48c4cc465db0b16056) | `` debian-devscripts: vendor patches ``                                                              |
| [`c1577cf7`](https://github.com/NixOS/nixpkgs/commit/c1577cf7854c7eb645f40061f0920495e2fed9dd) | `` python3Packages.boto3-stubs: 1.43.12 -> 1.43.13 ``                                                |
| [`b3729150`](https://github.com/NixOS/nixpkgs/commit/b37291500529d407fee6a0b3075f6a842dd2e7e9) | `` python3Packages.mypy-boto3-verifiedpermissions: 1.43.0 -> 1.43.13 ``                              |
| [`34095fc5`](https://github.com/NixOS/nixpkgs/commit/34095fc592d37075b5c08333d8514b71d5b0bf49) | `` python3Packages.mypy-boto3-sagemaker: 1.43.11 -> 1.43.13 ``                                       |
| [`3f209b16`](https://github.com/NixOS/nixpkgs/commit/3f209b16f95ad6c359712c15e83279904069eebf) | `` python3Packages.mypy-boto3-mediaconnect: 1.43.0 -> 1.43.13 ``                                     |
| [`a17af0c8`](https://github.com/NixOS/nixpkgs/commit/a17af0c851314ad03d51da4fa968ca16de997f17) | `` python3Packages.mypy-boto3-cleanrooms: 1.43.0 -> 1.43.13 ``                                       |
| [`7a399453`](https://github.com/NixOS/nixpkgs/commit/7a399453100071f5fc8075cde741ba68407f9fd0) | `` python3Packages.mypy-boto3-batch: 1.43.7 -> 1.43.13 ``                                            |
| [`1cf5bc6e`](https://github.com/NixOS/nixpkgs/commit/1cf5bc6ec8a0b69cab870c59d5f920c45645f482) | `` python3Packages.boto3-stubs: 1.43.11 -> 1.43.12 ``                                                |
| [`f0b1566c`](https://github.com/NixOS/nixpkgs/commit/f0b1566cfdadc1c09dd396f15930667266483e0e) | `` python3Packages.mypy-boto3-payment-cryptography-data: 1.43.0 -> 1.43.12 ``                        |
| [`cb20c443`](https://github.com/NixOS/nixpkgs/commit/cb20c443bb0250c44364e58cefa8d3f8a156794a) | `` python3Packages.mypy-boto3-mwaa: 1.43.5 -> 1.43.12 ``                                             |
| [`ba70e71e`](https://github.com/NixOS/nixpkgs/commit/ba70e71e2c5facb5e1dcb5cdcc749711a35e7629) | `` python3Packages.mypy-boto3-kms: 1.43.0 -> 1.43.12 ``                                              |
| [`b46148f6`](https://github.com/NixOS/nixpkgs/commit/b46148f671a2d2c0c7e5ddbc0879977bec9b29e4) | `` python3Packages.mypy-boto3-customer-profiles: 1.43.0 -> 1.43.12 ``                                |
| [`5f8ec489`](https://github.com/NixOS/nixpkgs/commit/5f8ec48914977589b03b019aca46eb519ba74561) | `` python3Packages.iamdata: 0.1.202605211 -> 0.1.202605221 ``                                        |
| [`518bf6c8`](https://github.com/NixOS/nixpkgs/commit/518bf6c8c67858912345caa20e50169ef3e004e9) | `` telemt: 3.4.11 -> 3.4.12 ``                                                                       |
| [`9b9d803a`](https://github.com/NixOS/nixpkgs/commit/9b9d803a3b6f585cfa0bc921f0ac6b2860bf094c) | `` poutine: 1.1.4 -> 1.1.5 ``                                                                        |
| [`1097c9d0`](https://github.com/NixOS/nixpkgs/commit/1097c9d03182b6f9882fb41e760788930a11b771) | `` trdl-client: 0.12.2 -> 0.12.3 ``                                                                  |
| [`598efa9f`](https://github.com/NixOS/nixpkgs/commit/598efa9f666472319d3569cc71768163681cd683) | `` rerun: 0.32.1 -> 0.32.2 ``                                                                        |
| [`c268f3ff`](https://github.com/NixOS/nixpkgs/commit/c268f3ff1ebc84a21ce98d0fd12aee2332b0a2f7) | `` fotema: fix build with ffmpeg 8.1 ``                                                              |
| [`e91ba0d7`](https://github.com/NixOS/nixpkgs/commit/e91ba0d7d23fcb749af8f9c43788ca2c0b9901e2) | `` mangareader: 2.4.0 -> 2.5.0 ``                                                                    |
| [`c85c1dcb`](https://github.com/NixOS/nixpkgs/commit/c85c1dcb4b719775c2831413ac48b4373cbdf9f5) | `` evcc: 0.306.3 -> 0.307.0 ``                                                                       |
| [`eb51dacc`](https://github.com/NixOS/nixpkgs/commit/eb51dacceaf2746b9001140a83f65e5349cc39bb) | `` _1password-gui: Upstream repackaged without changing version ``                                   |
| [`0bf5ad50`](https://github.com/NixOS/nixpkgs/commit/0bf5ad507102b88426d312896f4e903eeb13a6ed) | `` camilladsp: enable darwin build and add maintainer ``                                             |
| [`05b365b4`](https://github.com/NixOS/nixpkgs/commit/05b365b45a7ee27929e1a0a70d9d07413264951f) | `` visual-paradigm-ce: fix passthru.updateScript ``                                                  |
| [`24b80c45`](https://github.com/NixOS/nixpkgs/commit/24b80c45f2d5cfd4e8ea7f3a6b04de3e2dfc04c4) | `` nixos/starship: fix '$' escaping for bash and zsh ``                                              |
| [`4fef53db`](https://github.com/NixOS/nixpkgs/commit/4fef53dba2e8925a75c9b707e9e08161e4ef3da5) | `` libcss: vendor patches (no longer exist on server) ``                                             |
| [`b70649e9`](https://github.com/NixOS/nixpkgs/commit/b70649e94928253e40bcf3f6b553c2e9a7105843) | `` macopix: fix compilation with -std=gnu99 ``                                                       |
| [`2821def9`](https://github.com/NixOS/nixpkgs/commit/2821def9ff628479638a4731695626eca11109a7) | `` nylon: fix build with gcc 15 ``                                                                   |
| [`1accb5b5`](https://github.com/NixOS/nixpkgs/commit/1accb5b53a3c47b13e2cec9efa61654f69188c16) | `` libdom: vendor patch (no longer exists on server) ``                                              |
| [`794f5aa0`](https://github.com/NixOS/nixpkgs/commit/794f5aa087eeb0f7b25409281293dfd41b9209d2) | `` libsvgtiny: vendor patch (no longer on server) ``                                                 |
| [`aebdcfe3`](https://github.com/NixOS/nixpkgs/commit/aebdcfe36574bf0a31c915641d02152eee930915) | `` xqilla: fix src hash ``                                                                           |
| [`08b985a7`](https://github.com/NixOS/nixpkgs/commit/08b985a7ff77f986c7f4b2365a4467ca8a3e9903) | `` libinput: luaSupport flag ``                                                                      |
| [`3b649861`](https://github.com/NixOS/nixpkgs/commit/3b64986111a59fddd46c35357916f696bb79afba) | `` libinput: lib.meson* helpers ``                                                                   |
| [`d0eb5122`](https://github.com/NixOS/nixpkgs/commit/d0eb512214da0b36bb89b999165069b0988ea38d) | `` visual-paradigm-ce: 18.0.20260303 -> 18.0.20260511 ``                                             |
| [`b204c4ee`](https://github.com/NixOS/nixpkgs/commit/b204c4ee5b0f5b909251baa6793fcee742b7d7d5) | `` spotiflac: 7.1.6 -> 7.1.7 ``                                                                      |
| [`d14515c3`](https://github.com/NixOS/nixpkgs/commit/d14515c37b2f458f2637eea1c7b11e1a76ffa7c8) | `` survex: 1.4.20 -> 1.4.21 ``                                                                       |
| [`585063e2`](https://github.com/NixOS/nixpkgs/commit/585063e202eac73267bc415d5f74a5b05e7c3cf9) | `` libtapi: fix build with gcc 15 ``                                                                 |
| [`47a6a321`](https://github.com/NixOS/nixpkgs/commit/47a6a321a447244d8b70e014134caecfdb26f8d4) | `` python3Packages.cynthion: 0.2.4 -> 0.2.5 ``                                                       |
| [`cf416b91`](https://github.com/NixOS/nixpkgs/commit/cf416b91bdd0e2ee3c3cdb94457a1ee5329665bb) | `` nixos/navidrome: Default to plugins enabled ``                                                    |
| [`6fa3ef58`](https://github.com/NixOS/nixpkgs/commit/6fa3ef586f526a42b238ec526fd5a554a1797e48) | `` python3Packages.jsbeautifier: modernize and migrate to pyproject ``                               |
| [`5c78890d`](https://github.com/NixOS/nixpkgs/commit/5c78890d4f60fc2bf3f669635fd6747b967232e2) | `` radicle-desktop: 0.10.0 -> 0.11.0 ``                                                              |
| [`66656e87`](https://github.com/NixOS/nixpkgs/commit/66656e87b4c80387c3bc6af969b86e7de47d5c0f) | `` dcp: 0.23.4 -> 0.24.3 ``                                                                          |
| [`6f52b99f`](https://github.com/NixOS/nixpkgs/commit/6f52b99f49d320b1cafdcbff66f182cb658c69cd) | `` macaulay2: added meta.platforms ``                                                                |
| [`e9097092`](https://github.com/NixOS/nixpkgs/commit/e9097092600231738675818711f00704db74696d) | `` mathicgb: added meta.platforms ``                                                                 |
| [`effc9c3a`](https://github.com/NixOS/nixpkgs/commit/effc9c3ab7695c0c43217d89f9755c14e96941ae) | `` mathic: added meta.platforms ``                                                                   |
| [`0225e5ef`](https://github.com/NixOS/nixpkgs/commit/0225e5efa5d8ca90f74d848906d05297647715b6) | `` frobby: added meta.platforms ``                                                                   |
| [`c103da6a`](https://github.com/NixOS/nixpkgs/commit/c103da6a19c623e6e5c8c791d8012c29855bb802) | `` ci: add nixosTests.simple-container ``                                                            |
| [`70558450`](https://github.com/NixOS/nixpkgs/commit/70558450409e91a92d4a50b6fb2676cf0305cd5c) | `` nixos/release{,-small}: add nixosTests.simple-container ``                                        |
| [`cdc68a26`](https://github.com/NixOS/nixpkgs/commit/cdc68a268ce96acf39abf37c360ab1a58d6cdb17) | `` nixos/tests: add simple-container ``                                                              |
| [`244b7004`](https://github.com/NixOS/nixpkgs/commit/244b70040392ab04d0e570d984e1b654a8f58d77) | `` nixosTests.simple-vm: rename from nixosTests.simple ``                                            |
| [`0ea2bc77`](https://github.com/NixOS/nixpkgs/commit/0ea2bc77fd43d06da284dd802bb30603a0bf91b6) | `` python3Packages.jsonschema-rs: 0.39.0 -> 0.46.5 ``                                                |
| [`78b1d5b7`](https://github.com/NixOS/nixpkgs/commit/78b1d5b70be5a22b643ec1d189483f0076bdd7f0) | `` cargo-hakari: 0.9.37 -> 0.9.38 ``                                                                 |
| [`2f56cbaf`](https://github.com/NixOS/nixpkgs/commit/2f56cbaf8a459897bbe93b52b6d26005e05c2146) | `` gitfs: drop ``                                                                                    |
| [`135188a4`](https://github.com/NixOS/nixpkgs/commit/135188a4503ec6e2b6406d4f5a32fabeb062553a) | `` python3Packages.python-homewizard-energy: 10.0.1 -> 10.1.0 ``                                     |
| [`52612ae2`](https://github.com/NixOS/nixpkgs/commit/52612ae262354dacb2f29746f82a5d214231b133) | `` moonlight: 2026.5.0 -> 2026.5.2 ``                                                                |
| [`6d462b2d`](https://github.com/NixOS/nixpkgs/commit/6d462b2d090609b74e50d9e778830fbb50a31d4e) | `` thunderkittens: 0-unstable-2026-05-11 -> 0-unstable-2026-05-22 ``                                 |
| [`951a1ddc`](https://github.com/NixOS/nixpkgs/commit/951a1ddcf9b6dc13c576d7d0ba2a34ca7810689a) | `` python3Packages.ax-platform: disable tests with are time-sensitive ``                             |
| [`e7023fb8`](https://github.com/NixOS/nixpkgs/commit/e7023fb8c5a84c2e9ae3cfaf812664d61c093e70) | `` glab: 1.97.0 -> 1.99.0 ``                                                                         |
| [`5d6beea8`](https://github.com/NixOS/nixpkgs/commit/5d6beea86ec1d9969ddb2408ffa7919a2d3fa7c9) | `` python3Packages.snakemake-interface-logger-plugins: 2.0.1 -> 2.1.0 ``                             |
| [`8fdd30ac`](https://github.com/NixOS/nixpkgs/commit/8fdd30ac73e195ac1013d83a0c823ef209c86217) | `` snakemake: 9.16.3 -> 9.21.0 ``                                                                    |
| [`669f01f0`](https://github.com/NixOS/nixpkgs/commit/669f01f035e675f02530080d98f95606b32a418f) | `` python3Packages.snakemake-interface-logger-plugins: enable tests ``                               |
| [`2e7ebe35`](https://github.com/NixOS/nixpkgs/commit/2e7ebe3578cc9fdc24e7b6377ebb081c56724653) | `` python3Packages.snakemake-logger-plugin-rich: init at 0.4.1 ``                                    |
| [`d4eedeb6`](https://github.com/NixOS/nixpkgs/commit/d4eedeb694b5ba8a11244e07a6594a81f76ee6d8) | `` python3Packages.snakemake-storage-plugin-fs: cleanup ``                                           |
| [`12768496`](https://github.com/NixOS/nixpkgs/commit/1276849637da8a938d6d389f6cd628a85bec11fc) | `` python3Packages.snakemake-interface-report-plugins: cleanup ``                                    |
| [`f92b3f5b`](https://github.com/NixOS/nixpkgs/commit/f92b3f5b26b47cef096ce81d8149eb935461a2dd) | `` python3Packages.snakemake-interface-logger-plugins: cleanup ``                                    |
| [`0b4982f4`](https://github.com/NixOS/nixpkgs/commit/0b4982f44a58838f6af4f6b3462513c74fa9f983) | `` python3Packages.snakemake-interface-executor-plugins: cleanup ``                                  |
| [`90d358c2`](https://github.com/NixOS/nixpkgs/commit/90d358c2c5d718a94aca5b90da520e898fd34776) | `` python3Packages.snakemake-interface-common: cleanup ``                                            |
| [`e7dbc2e4`](https://github.com/NixOS/nixpkgs/commit/e7dbc2e41d6ad5903a52042a698a470865cc504c) | `` python3Packages.snakemake-storage-plugin-xrootd: 1.0.0 -> 1.1.0 ``                                |
| [`d27140ce`](https://github.com/NixOS/nixpkgs/commit/d27140ce9c05339409a38dd5c6665621c438d8bc) | `` python3Packages.pylance: 6.0.0 -> 6.0.1 ``                                                        |
| [`82c18045`](https://github.com/NixOS/nixpkgs/commit/82c18045d7338871fb5bba5e48f9c19fe44ade9a) | `` python3Packages.lance-namespace: 0.7.6 -> 0.7.7 ``                                                |
| [`4d8893c7`](https://github.com/NixOS/nixpkgs/commit/4d8893c7656a8f53a51bd5517d1e177e7459a849) | `` python3Packages.lance-namespace-urllib3-client: 0.7.6 -> 0.7.7 ``                                 |
| [`44619b7c`](https://github.com/NixOS/nixpkgs/commit/44619b7c78d87fc0372c310bd9b1671dbe62d025) | `` cabal-fmt: do not override Cabal-syntax ``                                                        |
| [`f7df550f`](https://github.com/NixOS/nixpkgs/commit/f7df550fcbe050d9ad56f523417d8bdf6eac5d11) | `` beamPackages.elixir_1_20: 1.20.0-rc.5 -> 1.20.0-rc.6 ``                                           |
| [`9e0eff34`](https://github.com/NixOS/nixpkgs/commit/9e0eff34c52153a10b1a8adb836c2cbfef9265f5) | `` nixos/test-driver: change run name to distinguish between different kinds of tests ``             |
| [`50ec0ab0`](https://github.com/NixOS/nixpkgs/commit/50ec0ab02a5bdc6af82cb8eb7394d0558746126c) | `` phpExtensions.mongodb: 2.3.1 -> 2.3.3 ``                                                          |
| [`9c42edbc`](https://github.com/NixOS/nixpkgs/commit/9c42edbc847d35e3712f91aa147f1f35fcce7650) | `` python3Packages.tree-sitter-zeek: 0.2.13 -> 0.2.15 ``                                             |
| [`9ffed393`](https://github.com/NixOS/nixpkgs/commit/9ffed393a63f797a98ef78fd0714a082767d17a0) | `` python3Packages.lerobot: 0.5.0 -> 0.5.1 ``                                                        |
| [`50070699`](https://github.com/NixOS/nixpkgs/commit/500706995d4928646c34937f55408ae1e1437c2c) | `` kallisto: fix build with gcc 15 ``                                                                |
| [`87041211`](https://github.com/NixOS/nixpkgs/commit/87041211199e19c0497d2e81df09059daf637aa7) | `` python3Packages.clickhouse-cityhash: correct license ``                                           |
| [`497dd138`](https://github.com/NixOS/nixpkgs/commit/497dd138cad7c56aa5ac19ef936b49a875214193) | `` hdf5: fix Darwin dylib install names ``                                                           |
| [`537c2bab`](https://github.com/NixOS/nixpkgs/commit/537c2bab37beec01113f0d981eca257bd7042bd0) | `` oh-my-posh: 29.13.1 -> 29.14.0 ``                                                                 |
| [`b0ac1aa8`](https://github.com/NixOS/nixpkgs/commit/b0ac1aa86405364fb2baa6bbec8952328424c34c) | `` nixos/test-driver: remove redundant `self.pid` state from `NspawnMachine` ``                      |
| [`11855b76`](https://github.com/NixOS/nixpkgs/commit/11855b765ccd4a6586449084ce8823bcf06c487e) | `` nixos/test-driver: null out self.pid when shutting down the container ``                          |
| [`081b749a`](https://github.com/NixOS/nixpkgs/commit/081b749ad6e7ca2b50a52af6f9a9689195ed7eff) | `` python3Packages.jupyter-collaboration: 4.3.0 -> 4.4.0 ``                                          |
| [`4a217fdc`](https://github.com/NixOS/nixpkgs/commit/4a217fdce1b45588c79304f0f93d73f449e8a84a) | `` xrootd: add meta.mainProgram ``                                                                   |
| [`3bf8cf64`](https://github.com/NixOS/nixpkgs/commit/3bf8cf64d5b80ab4c229e4ee3abab362b0579db1) | `` python3Packages.snakemake-storage-plugin-s3: cleanup ``                                           |
| [`5e8d069f`](https://github.com/NixOS/nixpkgs/commit/5e8d069fe355164e3e4e3c205845f724d012e21b) | `` python3Packages.snakemake-interface-storage-plugins: cleanup ``                                   |
| [`2a78a9a1`](https://github.com/NixOS/nixpkgs/commit/2a78a9a10c6e4b51711eec274484eaff9bd59883) | `` python3Packages.snakemake-interface-scheduler-plugins: cleanup ``                                 |
| [`53998a58`](https://github.com/NixOS/nixpkgs/commit/53998a58291b90e282cadcfc495dbee3574c193a) | `` python3Packages.snakemake-executor-plugin-cluster-generic: cleanup ``                             |
| [`e57b8ad6`](https://github.com/NixOS/nixpkgs/commit/e57b8ad67ad400977d787b715eb392871b184f66) | `` python3Packages.snakemake-storage-plugin-http: init at 0.3.1 ``                                   |
| [`43b38c0b`](https://github.com/NixOS/nixpkgs/commit/43b38c0b623247ab0f163c608d254867c2e1e2f3) | `` esphome: 2026.4.5 -> 2026.5.0 ``                                                                  |
| [`5fc76386`](https://github.com/NixOS/nixpkgs/commit/5fc76386cda92aaef5189aade56a2bc96f84c373) | `` ocamlPackages.tls: 2.0.2 → 2.1.0 ``                                                               |
| [`dca146f1`](https://github.com/NixOS/nixpkgs/commit/dca146f185df056f2e182353a6eca0da309dd2b4) | `` crossplane-cli: add myself as maintainer ``                                                       |
| [`4952b232`](https://github.com/NixOS/nixpkgs/commit/4952b23233860e4b26ab46ed73a2f66b3a5c6804) | `` crossplane-cli: 2.2.1 -> 2.3.0 ``                                                                 |
| [`dc2886ac`](https://github.com/NixOS/nixpkgs/commit/dc2886ac01ba6461342b77162472a3945f2398de) | `` python3Packages.snakemake-interface-storage-plugins: 4.3.2 -> 4.4.1 ``                            |
| [`dcccb23e`](https://github.com/NixOS/nixpkgs/commit/dcccb23e56c849d1cab82b7d1e41875e3ff66a37) | `` perfect_dark: 0-unstable-2026-05-02 -> 0-unstable-2026-05-21 ``                                   |
| [`71057a3a`](https://github.com/NixOS/nixpkgs/commit/71057a3a51441633a75c59cca3209399557711b2) | `` python3Packages.google-cloud-secret-manager: 2.27.0 -> 2.28.0 ``                                  |
| [`483eb8d6`](https://github.com/NixOS/nixpkgs/commit/483eb8d66a96f448c51f4106c551fc7653377358) | `` vscode-extensions.anthropic.claude-code: 2.1.146 -> 2.1.148 ``                                    |
| [`214cfc6c`](https://github.com/NixOS/nixpkgs/commit/214cfc6c70cf5004a287be82b56bd74064454bd5) | `` claude-code: 2.1.146 -> 2.1.148 ``                                                                |
| [`035234f8`](https://github.com/NixOS/nixpkgs/commit/035234f81a0be5e88a77d738d5a33b9a705a1db9) | `` powershell: 7.6.1 -> 7.6.2 ``                                                                     |
| [`3f387976`](https://github.com/NixOS/nixpkgs/commit/3f387976f4d15bbe6ae3e9d20c9fa6465222fad8) | `` src-cli: 7.2.1 -> 7.3.0 ``                                                                        |
| [`75821e69`](https://github.com/NixOS/nixpkgs/commit/75821e696abda2ecfa3f849b416808ac1a4b59fd) | `` clickhouse: 26.4.2.10-stable -> 26.5.1.882-stable ``                                              |
| [`49c886e5`](https://github.com/NixOS/nixpkgs/commit/49c886e5c17a9a5c52f7547ac0c207d83b3c8672) | `` python3Packages.resvg-py: 0.3.1 -> 0.3.2 ``                                                       |
| [`d26b1842`](https://github.com/NixOS/nixpkgs/commit/d26b184247e61fa9d37d7fd8d5ab0925621c2b65) | `` fop: add patch to "fix" maven versions ``                                                         |
| [`fa34339c`](https://github.com/NixOS/nixpkgs/commit/fa34339c18d3ff09cf8f0b58f5170d5fd0a20ffa) | `` flexget: 3.19.17 -> 3.19.21 ``                                                                    |
| [`95cca58f`](https://github.com/NixOS/nixpkgs/commit/95cca58f480d55b0e2ac9de42251be1378881633) | `` kanidm_1_10: 1.10.2 -> 1.10.3 ``                                                                  |
| [`f8e0f2a0`](https://github.com/NixOS/nixpkgs/commit/f8e0f2a09308ced97db5fc9a9e61041c7d544ea6) | `` dblab: 0.38.0 -> 0.39.0 ``                                                                        |
| [`7e557e7a`](https://github.com/NixOS/nixpkgs/commit/7e557e7ad14c72ba241705a52bd9507180b9a7ab) | `` fetchFromGitHub: only override fetchzip once ``                                                   |
| [`6f79f478`](https://github.com/NixOS/nixpkgs/commit/6f79f478cbfd6b36e8e55ced9ade2cdd3601205e) | `` python3Packages.homematicip: 2.11.0 -> 2.12.0 ``                                                  |
| [`310ed4e2`](https://github.com/NixOS/nixpkgs/commit/310ed4e2a8719fa71bf1160aeec548b2780d9951) | `` har-to-k6: 0.14.14 -> 0.14.15 ``                                                                  |
| [`b73a85d1`](https://github.com/NixOS/nixpkgs/commit/b73a85d19e5320522a1f857f57b22b17d6803b5d) | `` alive2: add alive-tv binary ``                                                                    |
| [`6cdc0665`](https://github.com/NixOS/nixpkgs/commit/6cdc0665a9a481cafcda3fbaf4230a2d669018fb) | `` jetbrains.rider: 2026.1.0.1 -> 2026.1.2 ``                                                        |
| [`059edbda`](https://github.com/NixOS/nixpkgs/commit/059edbdafe650eb34c2f504f8b7d9f831f5b2583) | `` codex: 0.131.0 -> 0.133.0 ``                                                                      |
| [`b9e0265f`](https://github.com/NixOS/nixpkgs/commit/b9e0265f2f8d201dd56a9fbecf897feaa4ab4b9e) | `` python3Packages.pulsectl: modernize and migrate to pyproject ``                                   |
| [`b1eb11bb`](https://github.com/NixOS/nixpkgs/commit/b1eb11bbd0910408590b38f5906d7cd1f2f06e06) | `` n64recomp: 0-unstable-2026-01-17 -> 0-unstable-2026-05-17 ``                                      |
| [`2a259335`](https://github.com/NixOS/nixpkgs/commit/2a259335fc0db5f3b7c7bd0078438c8b807d43de) | `` python3Packages.pyfireservicerota: 0.0.47 -> 0.0.48 ``                                            |
| [`ea2bdee0`](https://github.com/NixOS/nixpkgs/commit/ea2bdee030419ca675c4ecd55576484e5187a821) | `` code-cursor: 3.4.16 -> 3.5.17 ``                                                                  |
| [`996d8fc8`](https://github.com/NixOS/nixpkgs/commit/996d8fc8cb47a1e8915f5f22121b16abb16f43d1) | `` libphonenumber: 9.0.30 -> 9.0.31 ``                                                               |
| [`8443be28`](https://github.com/NixOS/nixpkgs/commit/8443be281301c17a66069902f03aceeb1c9c501d) | `` vkd3d: 1.19 -> 2.0 ``                                                                             |
| [`36587c86`](https://github.com/NixOS/nixpkgs/commit/36587c86096589ced1392cb2e0bc2045960c0ea2) | `` archisteamfarm: 6.3.4.2 -> 6.3.6.0 ``                                                             |
| [`5eba89ff`](https://github.com/NixOS/nixpkgs/commit/5eba89ff4364dd0632210756da112f57578764e3) | `` nixos/nspawn-container: add "usr/bin" ``                                                          |
| [`9882a4e3`](https://github.com/NixOS/nixpkgs/commit/9882a4e3c715ef2e2ee52f570514e3cfaaf2e456) | `` googleearth-pro: 7.3.6.10201 -> 7.3.7.1155 ``                                                     |
| [`e6673f2e`](https://github.com/NixOS/nixpkgs/commit/e6673f2e7345026e4bc3c4d0d264d13602558b54) | `` vkquake: 1.32.3.1 -> 1.34.1 ``                                                                    |
| [`8c0ea07a`](https://github.com/NixOS/nixpkgs/commit/8c0ea07af98c2672eefcd08615e57f4e1638ab5b) | `` git-archive-all: switch to pyproject ``                                                           |
| [`474a47a0`](https://github.com/NixOS/nixpkgs/commit/474a47a0b3200a314deca4c99fbf81959306d690) | `` wayfarer: 1.2.4-unstable-2025-04-12 -> 1.4.0 ``                                                   |
| [`bf0ecacf`](https://github.com/NixOS/nixpkgs/commit/bf0ecacf6c66a3dee4f32bef19bbd51a006a812d) | `` pgdog: 0.1.40 -> 0.1.41 ``                                                                        |
| [`ecf4b2b1`](https://github.com/NixOS/nixpkgs/commit/ecf4b2b14b0d83b28e330a6721c1b2e6464cf0dd) | `` niimblue: init at 0-unstable-2026-05-04 ``                                                        |
| [`238d721c`](https://github.com/NixOS/nixpkgs/commit/238d721c6913b18625ab26f20116de068e1f71c3) | `` python3Packages.bthome-ble: 3.22.1 -> 3.23.2 ``                                                   |
| [`296da583`](https://github.com/NixOS/nixpkgs/commit/296da583a56a8a030c57e82751847bfdc2e0e1c5) | `` git-aggregator: switch to pyproject ``                                                            |
| [`eb9d115a`](https://github.com/NixOS/nixpkgs/commit/eb9d115a7a5cff1abc853076f2d7d158d8569427) | `` sunsetr: 0.11.1 -> 0.12.2 ``                                                                      |
| [`43657777`](https://github.com/NixOS/nixpkgs/commit/436577778a7e429aa7af4f6809fa65867616bf34) | `` evince: 48.1 -> 48.4 ``                                                                           |
| [`dbcdf83b`](https://github.com/NixOS/nixpkgs/commit/dbcdf83bb770c06359b8fc662218ad43a983efab) | `` alkalami: use finalAttrs ``                                                                       |
| [`76a21af2`](https://github.com/NixOS/nixpkgs/commit/76a21af26670ec8d82c0bef471e8d3642ee2812b) | `` alkalami: use installFonts ``                                                                     |
| [`98093105`](https://github.com/NixOS/nixpkgs/commit/980931056eccb1dea2f2e8ce7b26405b31992fe3) | `` installFonts: make preInstall hook ``                                                             |
| [`c4f37e2b`](https://github.com/NixOS/nixpkgs/commit/c4f37e2b31e063863d78474396ffc2bcf3da96d2) | `` python3Packages.ax-platform: disable failing test ``                                              |
| [`02a6844d`](https://github.com/NixOS/nixpkgs/commit/02a6844d57be1b1aea87e3d64a009a3071774565) | `` json-sort: 1.1.0 -> 1.1.5 ``                                                                      |
| [`d2eb1ebf`](https://github.com/NixOS/nixpkgs/commit/d2eb1ebfc2b71462b3431a49fab5aa512194bb04) | `` mup: fix build with gcc 15 ``                                                                     |
| [`279f0df0`](https://github.com/NixOS/nixpkgs/commit/279f0df0b1e4773f9ad9f99c7eb7f9c7f0cb63b9) | `` gpxsee: 16.6 -> 16.7 ``                                                                           |
| [`4539a5b8`](https://github.com/NixOS/nixpkgs/commit/4539a5b8218a0caaac5ae89c9d4fbc5133f2e21a) | `` ollama: 0.23.4 -> 0.24.0 ``                                                                       |
| [`f10e4864`](https://github.com/NixOS/nixpkgs/commit/f10e48647c426e5c972bb5b2699198c2f89d0494) | `` jetbrains.*: updater: use channel IDs instead of names ``                                         |
| [`1cf0065f`](https://github.com/NixOS/nixpkgs/commit/1cf0065f1804b9a0a2a0b5dbc79bd5945b360973) | `` dmensamenu: migrate to pyproject ``                                                               |
| [`391e8921`](https://github.com/NixOS/nixpkgs/commit/391e892124f1cd78d9b1432fbd9a4f0e3e825f20) | `` displaycal: migrate to pyproject ``                                                               |
| [`30a93455`](https://github.com/NixOS/nixpkgs/commit/30a934559fbd1e21193de0f61047e10707e17cb4) | `` _1password-gui-beta: 8.12.12-43.BETA -> 8.12.22-15.BETA ``                                        |
| [`a5209d05`](https://github.com/NixOS/nixpkgs/commit/a5209d05eeaa64e08c1de3113715164c9c90d559) | `` python3Packages.pyvista: 0.48.2 -> 0.48.4 ``                                                      |
| [`dbe7e407`](https://github.com/NixOS/nixpkgs/commit/dbe7e407cfb6c55003628b5990debfb7de7fd85e) | `` python3Packages.vector: 1.8.0 -> 1.8.1 ``                                                         |
| [`c9feb44b`](https://github.com/NixOS/nixpkgs/commit/c9feb44bef95feb7b6d91308e4ed03760bd81e95) | `` jetbrains.goland: 2026.1.1 -> 2026.1.2 ``                                                         |
| [`22362851`](https://github.com/NixOS/nixpkgs/commit/22362851335c9793ec87035074d04799b29a63a8) | `` jetbrains.clion: 2026.1.1 -> 2026.1.2 ``                                                          |
| [`228d96c5`](https://github.com/NixOS/nixpkgs/commit/228d96c5c6a67da24e3e9f550da786dec79c373e) | `` jetbrains.phpstorm: 2026.1.1 -> 2026.1.2 ``                                                       |
| [`84068521`](https://github.com/NixOS/nixpkgs/commit/84068521eefcb7f75944c909d2b07b259c02ce92) | `` jetbrains.gateway: 2026.1.1 -> 2026.1.2 ``                                                        |
| [`1a171d67`](https://github.com/NixOS/nixpkgs/commit/1a171d6722e430404a9189e363a7c9a48ff64afc) | `` jetbrains.ruby-mine: 2026.1.1 -> 2026.1.2 ``                                                      |
| [`166a2806`](https://github.com/NixOS/nixpkgs/commit/166a28066eb8d08cd270409d73b6e8f594d86a49) | `` jetbrains.rust-rover: 2026.1.1 -> 2026.1.2 ``                                                     |
| [`0d277679`](https://github.com/NixOS/nixpkgs/commit/0d277679c03180711bb98e851e1b9fdf587c1cc2) | `` maintainers: remove davisrichard437 ``                                                            |
| [`91a0d7b9`](https://github.com/NixOS/nixpkgs/commit/91a0d7b98ed492d8d04c706bb30a5210a3f609ce) | `` terraform-providers.yandex-cloud_yandex: 0.202.0 -> 0.204.0 ``                                    |
| [`57d93f0b`](https://github.com/NixOS/nixpkgs/commit/57d93f0b835c483607791684ad3d813834107a46) | `` nixos/hyprland: link lua stubs ``                                                                 |
| [`604f7cdf`](https://github.com/NixOS/nixpkgs/commit/604f7cdfa17a78342736dce2dca69033da828580) | `` gitea: 1.26.1 -> 1.26.2 ``                                                                        |
| [`83c59da4`](https://github.com/NixOS/nixpkgs/commit/83c59da4dae0ae2d784ce2439ad45fb6ff048741) | `` igraph: enable (and fix) html documentation generation ``                                         |
| [`d4125265`](https://github.com/NixOS/nixpkgs/commit/d412526504fc4cd46650be22071a762dd4e05494) | `` ddhx: 0.9.2 -> 0.9.3 ``                                                                           |
| [`d817bf83`](https://github.com/NixOS/nixpkgs/commit/d817bf83c7d55984a5ef3fa98f83fda3ebca3393) | `` dnsproxy: 0.81.3 -> 0.81.4 ``                                                                     |
| [`6849aad8`](https://github.com/NixOS/nixpkgs/commit/6849aad8c63b4a2e7184cbd029fbdd091122b95b) | `` python3Packages.language-tool-python: 3.3.1 -> 3.4.0 ``                                           |
| [`37413baa`](https://github.com/NixOS/nixpkgs/commit/37413baa3a41291aaa6bb091ca94a0b4f9b0eea9) | `` vdr-streamdev: 0.6.4 -> 0.6.5 ``                                                                  |
| [`68e9f5ed`](https://github.com/NixOS/nixpkgs/commit/68e9f5ed8f9db8392c8b170227f688db5be0ec93) | `` vdr-vnsiserver: 1.8.3 -> 1.8.4 ``                                                                 |
| [`62785fc7`](https://github.com/NixOS/nixpkgs/commit/62785fc7f7159f469d8ddf7365aa821b9f2722a5) | `` vdr-skin-nopacity: 1.1.19 -> 1.1.20 ``                                                            |
| [`195352a9`](https://github.com/NixOS/nixpkgs/commit/195352a9b27b9e91b9dc6c6c893cbb8291c69439) | `` vdr-markad: 4.2.19 -> 4.2.22 ``                                                                   |
| [`63710c9d`](https://github.com/NixOS/nixpkgs/commit/63710c9d9ed94d1baedd8df6766fd53304a8daaf) | `` ndg: init at 2.8.0 ``                                                                             |
| [`d373280b`](https://github.com/NixOS/nixpkgs/commit/d373280bd0305e6ddb993c34c11e267df89718c2) | `` vscode-extensions: Skips marketplace validation-failed extension versions ``                      |
| [`8459e001`](https://github.com/NixOS/nixpkgs/commit/8459e001cacf5d6a7917faad00626e1ac08c70a6) | `` yabai: 7.1.24 -> 7.1.25 ``                                                                        |
| [`0f6752ac`](https://github.com/NixOS/nixpkgs/commit/0f6752acaf40e84b61a75345feeb409e9836ac4e) | `` python3Packages.urllib3-future: 2.20.905 -> 2.20.906 ``                                           |
| [`2218a58c`](https://github.com/NixOS/nixpkgs/commit/2218a58c1519a6b19f70ee69fa1b027d442bfbb3) | `` kitty: 0.46.2 -> 0.47.0 ``                                                                        |
| [`f23b117e`](https://github.com/NixOS/nixpkgs/commit/f23b117e50f3742b1b29d46d27898d4c2d8e0d31) | `` lib.showWarnings: inherit lib functions, beta reduce for free ``                                  |
| [`59d05494`](https://github.com/NixOS/nixpkgs/commit/59d054945fe4163e2b3ad75cc954e9071d96095c) | `` go-jet: 2.14.1 -> 2.15.0 ``                                                                       |
| [`47508449`](https://github.com/NixOS/nixpkgs/commit/47508449e35008d702cf4c25ffc233b15f1a9b2b) | `` glaze: 7.6.0 -> 7.7.0 ``                                                                          |
| [`7f6eb89a`](https://github.com/NixOS/nixpkgs/commit/7f6eb89aeb1220bfa25e6ad9e3290c4607d70452) | `` lib.{importJSON,importTOML}: inherit builtins to global scope ``                                  |
| [`f023dff3`](https://github.com/NixOS/nixpkgs/commit/f023dff3203790816afd8c350a229b8bee24ae2b) | `` gotlsaflare: 2.8.2 -> 2.8.3 ``                                                                    |
| [`0a4c1584`](https://github.com/NixOS/nixpkgs/commit/0a4c158427a9f0ff08d6bb46d9d133be1093ae84) | `` igraph: remove unused fop dependency ``                                                           |
| [`1f83c2cc`](https://github.com/NixOS/nixpkgs/commit/1f83c2cc226b4f96e36d42c4a5341fe1fd155e60) | `` lib.toBaseDigits: avoid reversing list ``                                                         |
| [`19fcf500`](https://github.com/NixOS/nixpkgs/commit/19fcf5006ab7a2b131b91f0fe37411bfee467f23) | `` lib.mirrorFunctionArgs: inline call to setFunctionArgs ``                                         |
| [`d02c939b`](https://github.com/NixOS/nixpkgs/commit/d02c939bfc2b22f64b778532f0dc4c98f03c2241) | `` aider-chat: add missing rsa dependency to fix build ``                                            |
| [`cbe17527`](https://github.com/NixOS/nixpkgs/commit/cbe1752727e6b1d1830197bddd843c733e8c0414) | `` muffet: 2.11.3 -> 2.11.4 ``                                                                       |
| [`102913e7`](https://github.com/NixOS/nixpkgs/commit/102913e76f1e34d601c77eacd1dbc6f56acc18b1) | `` sqlint: update deps to fix build failure ``                                                       |
| [`35b7c1ee`](https://github.com/NixOS/nixpkgs/commit/35b7c1ee11b665b702afb2a82e3965bb22fe35b1) | `` ruff: 0.15.13 -> 0.15.14 ``                                                                       |
| [`732700f5`](https://github.com/NixOS/nixpkgs/commit/732700f57744fbf0a27e6af3fb79a1c1e314abe6) | `` openorbitaloptimizer: 0.2.0 -> 0.3.0 ``                                                           |
| [`dad9d362`](https://github.com/NixOS/nixpkgs/commit/dad9d362247d501f692a6e1254e1e60ca02cbf91) | `` apkeditor: 1.4.8 -> 1.4.9 ``                                                                      |
| [`ec524ede`](https://github.com/NixOS/nixpkgs/commit/ec524ede460193af2921d403afb944b9affc6afa) | `` vscode-extensions.csharpier.csharpier-vscode: 10.0.2 -> 10.0.3 ``                                 |
| [`f04d36a8`](https://github.com/NixOS/nixpkgs/commit/f04d36a8d3580b096305a30aec2da90bf464495c) | `` lunar-client: 3.6.10 -> 3.6.11 ``                                                                 |
| [`0f965ef1`](https://github.com/NixOS/nixpkgs/commit/0f965ef19b3b53dae3ec72461cf99ebf0012722e) | `` home-assistant-custom-components.dreo: 1.8.8 -> 1.9.0 ``                                          |
| [`e663513d`](https://github.com/NixOS/nixpkgs/commit/e663513dffb5a1e55d5a35f1d000c3f51a2f03da) | `` mattermost: 11.7.0 -> 11.7.1 ``                                                                   |
| [`309d5c16`](https://github.com/NixOS/nixpkgs/commit/309d5c169b871f8b0584ab93132d02067a682b42) | `` doc: don't use sha256 and non-sri hashes in user docs ``                                          |
| [`6b9bcbfc`](https://github.com/NixOS/nixpkgs/commit/6b9bcbfc5f1192c63897265d19217e1eb41fea2f) | `` terraform-providers.tencentcloudstack_tencentcloud: 1.82.93 -> 1.82.95 ``                         |
| [`b142cf26`](https://github.com/NixOS/nixpkgs/commit/b142cf26b3ea9a24bcf809d5524a3dea30e1b6ee) | `` meshtasticd: 2.7.18.fb3bf78 -> 2.7.23.b246bcd ``                                                  |
| [`8dff08cb`](https://github.com/NixOS/nixpkgs/commit/8dff08cb12c3945ee3ce90ddfc8e1fe4cbc57b17) | `` opencode: 1.15.5 -> 1.15.7 ``                                                                     |
| [`94e94355`](https://github.com/NixOS/nixpkgs/commit/94e943555e5ca44d08d0edfa7386179da80901dc) | `` firefox-bin-unwrapped: 151.0 -> 151.0.1 ``                                                        |
| [`c335effc`](https://github.com/NixOS/nixpkgs/commit/c335effce2c24d0249367f02d43c5087605a408b) | `` python3Packages.jupyter-collaboration-ui: 2.3.0 -> 2.4.0 ``                                       |
| [`296ec5dc`](https://github.com/NixOS/nixpkgs/commit/296ec5dc4a2fccefadd3d697be04e142290db940) | `` firefox-unwrapped: 151.0 -> 151.0.1 ``                                                            |
| [`f5dfa65f`](https://github.com/NixOS/nixpkgs/commit/f5dfa65f33c696db72fe0712ce076818556bb54f) | `` cargo-about: 0.8.4 -> 0.9.0 ``                                                                    |
| [`2ab21967`](https://github.com/NixOS/nixpkgs/commit/2ab2196703321019d50ce69bcfac9e925f3aafa1) | `` python3Packages.elevenlabs: 2.47.0 -> 2.49.1 ``                                                   |
| [`28c08bac`](https://github.com/NixOS/nixpkgs/commit/28c08bac76ee9f367a418bf21a53e78e323ec07e) | `` python3Packages.telnetlib3: 4.0.2 -> 4.0.3 ``                                                     |
| [`8a2a19a9`](https://github.com/NixOS/nixpkgs/commit/8a2a19a976cfb5937c1b524bd314a15aa1bb35d8) | `` python3Packages.serialx: 1.7.3 -> 1.8.0 ``                                                        |
| [`5792087b`](https://github.com/NixOS/nixpkgs/commit/5792087ba6ea61836e7c74bce2d76309b3fbb55b) | `` python3Packages.marisa-trie: fix tests with marisa 0.3.1 ``                                       |
| [`e3721159`](https://github.com/NixOS/nixpkgs/commit/e3721159a3d5244439d00da75621c26f0792a452) | `` marisa: 0.3.0 -> 0.3.1 ``                                                                         |

*... and 5052 more commits (truncated)*