### PR TITLE
chore(flake/astal): `d8738f97` -> `11842ae3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -75,11 +75,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1779465550,
-        "narHash": "sha256-lsLyO08Gv9eLvUYd6I+UUuZeT4w5M1vU/ulo5QICoNo=",
+        "lastModified": 1782062955,
+        "narHash": "sha256-FGZHls4eQJ8y3pvf5h3b83PfXlve3vD/Gj3g1qoAK6o=",
         "owner": "Aylur",
         "repo": "astal",
-        "rev": "d8738f97ed01f4d87f668df35fa7bbad795c9e49",
+        "rev": "11842ae3045c1367fb3a62a2302dba0d9ccb4a33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                       | Message                                                                                |
| -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`11842ae3`](https://github.com/Aylur/astal/commit/11842ae3045c1367fb3a62a2302dba0d9ccb4a33) | `` fix(mpris): check base64 url ``                                                     |
| [`0b7ba3df`](https://github.com/Aylur/astal/commit/0b7ba3df264b7a17a4811b0768108b84620b28f4) | `` feat(mpris): support base64 art uris ``                                             |
| [`465aefb1`](https://github.com/Aylur/astal/commit/465aefb1058fe87c48a3e7353dc3fb4b560ea6ec) | `` fix(mpris): manually handle http urls ``                                            |
| [`1c762bf4`](https://github.com/Aylur/astal/commit/1c762bf4cf2f7e2aab1648d562dc98d2abc6e6ec) | `` feat(greet): LoginError, Greeter, CLI ``                                            |
| [`948805f6`](https://github.com/Aylur/astal/commit/948805f6e8cf7f8c08eba06ab1db1eef0e75e3a0) | `` fix(tray): guard on_item_unregister against items that never became ready (#451) `` |
| [`271851bb`](https://github.com/Aylur/astal/commit/271851bbc07748100382ae7caf6ef71c70c01bfc) | `` fix(wireplumber): emit notify signals for device property ``                        |
| [`5dafa377`](https://github.com/Aylur/astal/commit/5dafa377b1092020548a06ffc4bf21b7d31ad9cd) | `` feat(wireplumber): stream target falls back to node.target ``                       |