### PR TITLE
chore(flake/git-hooks): `61ab0e80` -> `3bbec39b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -226,11 +226,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`8455184c`](https://github.com/cachix/git-hooks.nix/commit/8455184cd867897bc9f154531df4bb53c1f384f6) | `` feat: allow configuring clippy allowed lints `` |