### PR TITLE
chore(flake/git-hooks): `3bbec39b` -> `43b3c1ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,17 +220,16 @@
     "git-hooks_2": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "gitignore": "gitignore_2",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -242,7 +241,7 @@
     "git-hooks_3": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "gitignore": "gitignore_3",
+        "gitignore": "gitignore_2",
         "nixpkgs": [
           "precommit",
           "nixpkgs"
@@ -286,27 +285,6 @@
       }
     },
     "gitignore_2": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_3": {
       "inputs": {
         "nixpkgs": [
           "precommit",


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`92816613`](https://github.com/cachix/git-hooks.nix/commit/9281661306748b9b39e1ce0c224ca57aa4ceca10) | `` fix: replace 'pre-commit' by `cfg.package.pname` ``                            |
| [`ba93239e`](https://github.com/cachix/git-hooks.nix/commit/ba93239ef4c762129becfb06ab4923bb8bb442c8) | `` Improve documentation ``                                                       |
| [`ea7de856`](https://github.com/cachix/git-hooks.nix/commit/ea7de856201af01c1f6acf142b74d91d41758d14) | `` Add an `inPlace` option (default: false) for cmake-format ``                   |
| [`92326f29`](https://github.com/cachix/git-hooks.nix/commit/92326f29cbe89d6f17b73f2ca9ba9b78e60fc407) | `` chore(deps): lock file maintenance ``                                          |
| [`2df91034`](https://github.com/cachix/git-hooks.nix/commit/2df91034e4fcb88f8c46ca58410de43bd9a57e30) | `` inputs: drop gitignore.nix ``                                                  |
| [`ee8273c2`](https://github.com/cachix/git-hooks.nix/commit/ee8273c2af432729c576692844e3e1e4af30b0fc) | `` feat: add google-java-format ``                                                |
| [`67cbb7a1`](https://github.com/cachix/git-hooks.nix/commit/67cbb7a15639c58409bd03c9d101ce51a52244c8) | `` feat: expose `extendModules` to allow for module overrides ``                  |
| [`6be88240`](https://github.com/cachix/git-hooks.nix/commit/6be8824087380be84248ca064f51d153a330020a) | `` feat: add air hook ``                                                          |
| [`6a3d22f3`](https://github.com/cachix/git-hooks.nix/commit/6a3d22f3c766e9a87489db8774e3ebc81a999ebb) | `` feat: add hooks.biome.settings.flags for extra CLI flags ``                    |
| [`f42abcf9`](https://github.com/cachix/git-hooks.nix/commit/f42abcf9d258b3ac7334ecc8ad92b56c62341340) | `` statix: pass list settings as repeated flags instead of space-joined string `` |