### PR TITLE
chore(flake/astal): `11842ae3` -> `9dac92f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -75,11 +75,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1782062955,
-        "narHash": "sha256-FGZHls4eQJ8y3pvf5h3b83PfXlve3vD/Gj3g1qoAK6o=",
+        "lastModified": 1784907849,
+        "narHash": "sha256-wtypRfcfVvofMON6xemTObJCpPWLRyBoqLrvzgnLYlI=",
         "owner": "Aylur",
         "repo": "astal",
-        "rev": "11842ae3045c1367fb3a62a2302dba0d9ccb4a33",
+        "rev": "9dac92f20e6c89b9373bbb238c49b1cb115724db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                       | Message                                                                           |
| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`9dac92f2`](https://github.com/Aylur/astal/commit/9dac92f20e6c89b9373bbb238c49b1cb115724db) | `` fix(cava): nix build ``                                                        |
| [`72aa35f3`](https://github.com/Aylur/astal/commit/72aa35f340cb4ef68a767c31277dc511ccd258f8) | `` fix(cava): bump libcava to 1.0.0 ``                                            |
| [`fd94e333`](https://github.com/Aylur/astal/commit/fd94e333c8bd45557291c805f1df79d5f787d590) | `` fix(wireplumber): correct output-route-id property name typo (#460) ``         |
| [`04454c22`](https://github.com/Aylur/astal/commit/04454c22094401cc8e682cfe1f8ecc3194cac5f9) | `` fix(bluetooth): signals when removing bluetooth devices and adapters (#456) `` |