### PR TITLE
chore(flake/precommit): `6241f83d` -> `01acaa60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,18 +242,17 @@
     "git-hooks_3": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "gitignore": "gitignore_3",
         "nixpkgs": [
           "precommit",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -288,28 +287,6 @@
     "gitignore_2": {
       "inputs": {
         "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_3": {
-      "inputs": {
-        "nixpkgs": [
-          "precommit",
           "git-hooks",
           "nixpkgs"
         ]
@@ -646,11 +623,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1782849529,
-        "narHash": "sha256-VqfO+f4MmXO6wKz3emHMlQwj1NkIxuFeZyYeIGgqX9U=",
+        "lastModified": 1785487287,
+        "narHash": "sha256-3eF2bngygCD5mfzUKbXWYFXRSCmHcPnEiHZdbeyGc4k=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "6241f83dfeaae7a9c638d6981dcb1fd00a65f020",
+        "rev": "01acaa60808b41153970f9b0985ffb142b2ebfe5",
         "type": "github"
       },
       "original": {
@@ -693,11 +670,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1782789458,
-        "narHash": "sha256-CR55gKCChD9ffN1Ag5az20Z3RD4tylHlcM1SSohkMA8=",
+        "lastModified": 1785476452,
+        "narHash": "sha256-/CXwCFPS41rb/JI2VitKCgVK6V5E6/sfw5ke3B9zyVQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "067959ef838c440558ca519cf08ca87f43c3db3a",
+        "rev": "6ef009bf4c4873cdc1a621826722bdea7c03e62c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                                                    |
| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`01acaa60`](https://github.com/fredsystems/pre-commit-checks/commit/01acaa60808b41153970f9b0985ffb142b2ebfe5) | `` chore(flake/rust-overlay): 471286a5 -> 6ef009bf ``                      |
| [`ff4b38d2`](https://github.com/fredsystems/pre-commit-checks/commit/ff4b38d25952a7b818f3b2e0edc749bf6c11b371) | `` chore(flake/nixpkgs): 753cc8a3 -> e2587cae ``                           |
| [`db58dc2e`](https://github.com/fredsystems/pre-commit-checks/commit/db58dc2e11c3a90ba0df698aa6da09199b0ce283) | `` chore(flake/rust-overlay): 06817500 -> 471286a5 ``                      |
| [`8afeac59`](https://github.com/fredsystems/pre-commit-checks/commit/8afeac598b421e3b7b2772eaa699cbdfe967b76c) | `` chore(flake/git-hooks): bca82caa -> 43b3c1ab ``                         |
| [`50bd447e`](https://github.com/fredsystems/pre-commit-checks/commit/50bd447e1d3206ea63716ef6c77ac0deba9f0276) | `` chore(flake/nixpkgs): e7a3ca80 -> 753cc8a3 ``                           |
| [`1f9ef53d`](https://github.com/fredsystems/pre-commit-checks/commit/1f9ef53dcdced2019d6b8ccca22a3f9bb455b819) | `` chore(flake/rust-overlay): a286e5b9 -> 06817500 ``                      |
| [`7ffbe4d2`](https://github.com/fredsystems/pre-commit-checks/commit/7ffbe4d244ef810e871ff616988753131c9595e8) | `` updates ``                                                              |
| [`538e1735`](https://github.com/fredsystems/pre-commit-checks/commit/538e1735c9dc44bb8fc3bc2918a3a5618896a60d) | `` updates ``                                                              |
| [`53d43fa0`](https://github.com/fredsystems/pre-commit-checks/commit/53d43fa05b4de2c1041d41a21d58efae2b674c59) | `` chore(flake/nixpkgs): 0bb7ec54 -> e7a3ca80 ``                           |
| [`fc8d9b93`](https://github.com/fredsystems/pre-commit-checks/commit/fc8d9b9382519b7f1c256da05eebe82aa7aedfaf) | `` chore(flake/rust-overlay): 072adf9b -> a286e5b9 ``                      |
| [`3076ff29`](https://github.com/fredsystems/pre-commit-checks/commit/3076ff29e23e52d8c3cd4c18d8ec086ed6ba8380) | `` chore(flake/nixpkgs): b5aa0fbd -> 0bb7ec54 ``                           |
| [`bc538894`](https://github.com/fredsystems/pre-commit-checks/commit/bc53889457a8989d181d68d3d0d40fbe5f0d0a50) | `` fix(checks): stop failing CI over markdown table widths ``              |
| [`b1c8ac3f`](https://github.com/fredsystems/pre-commit-checks/commit/b1c8ac3f736a4b1a05650867d1492beb2b875b6b) | `` fix(nix): skip flaky nixpkgs pre-commit test_output_isatty on darwin `` |
| [`edc9ac49`](https://github.com/fredsystems/pre-commit-checks/commit/edc9ac49ba8bcf968fcdad3d0605cf8aaddfab90) | `` chore(flake/rust-overlay): e7a078c7 -> 072adf9b ``                      |
| [`63f45c8b`](https://github.com/fredsystems/pre-commit-checks/commit/63f45c8b2c78f4a9b01e274ac68004ff959b930d) | `` chore(flake/rust-overlay): 13139aef -> e7a078c7 ``                      |
| [`5e1f5b7a`](https://github.com/fredsystems/pre-commit-checks/commit/5e1f5b7a2446318f1e3f94396df91a7d096e5cc4) | `` chore(flake/git-hooks): 9f7e9911 -> bca82caa ``                         |
| [`436b4b1f`](https://github.com/fredsystems/pre-commit-checks/commit/436b4b1f99b0ff4fbd2e03af2a90227638b16fb2) | `` chore(deps): lock file maintenance (#35) ``                             |
| [`e91f225e`](https://github.com/fredsystems/pre-commit-checks/commit/e91f225eb26e151c86c865e49147a60fc36d0cca) | `` chore(deps): update actions/checkout action to v7 (#34) ``              |