### PR TITLE
chore(flake/hyprshutdown): `db1f38b0` -> `659e7031`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -401,11 +401,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1778610771,
-        "narHash": "sha256-msCMXV9k9+1siOPaxSzNJwx/o8pn2srCR4h0pxyW/WE=",
+        "lastModified": 1784400995,
+        "narHash": "sha256-D06Ik04uFMdR3cJxdMBfqGpdz43m4R0/iTvrhLEmq1c=",
         "owner": "hyprwm",
         "repo": "hyprshutdown",
-        "rev": "db1f38b03b173984ae9ed3abeb9750583c9bbd91",
+        "rev": "659e70312109c3cfe38e32ec3cb62a3d999f8819",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                 |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`659e7031`](https://github.com/hyprwm/hyprshutdown/commit/659e70312109c3cfe38e32ec3cb62a3d999f8819) | `` internal: include missing include in OS.cpp (#34) `` |